### PR TITLE
027: Build zapp package

### DIFF
--- a/pkg/zapp/go.mod
+++ b/pkg/zapp/go.mod
@@ -1,3 +1,7 @@
 module github.com/zarlcorp/core/pkg/zapp
 
 go 1.24.4
+
+require github.com/zarlcorp/core/pkg/zoptions v0.0.0
+
+replace github.com/zarlcorp/core/pkg/zoptions => ../zoptions

--- a/pkg/zapp/options.go
+++ b/pkg/zapp/options.go
@@ -1,0 +1,8 @@
+package zapp
+
+// WithName overrides the default application name.
+func WithName(name string) Option {
+	return func(a *App) {
+		a.name = name
+	}
+}

--- a/pkg/zapp/zapp.go
+++ b/pkg/zapp/zapp.go
@@ -1,0 +1,106 @@
+// Package zapp provides application lifecycle management for zarlcorp tools.
+//
+// zapp is a toolkit, not a framework. The consumer owns main and wires
+// things together explicitly. zapp handles resource tracking with ordered
+// cleanup, signal-based context cancellation, and functional options.
+//
+// # Usage
+//
+//	func main() {
+//		app := zapp.New(zapp.WithName("myservice"))
+//
+//		ctx, cancel := zapp.SignalContext(context.Background())
+//		defer cancel()
+//
+//		db := openDB()
+//		app.Track(db)
+//
+//		srv := startServer(ctx, db)
+//		app.Track(zapp.CloserFunc(func() error {
+//			return srv.Shutdown(context.Background())
+//		}))
+//
+//		<-ctx.Done()
+//
+//		if err := app.Close(); err != nil {
+//			slog.Error("shutdown", "err", err)
+//			os.Exit(1)
+//		}
+//	}
+package zapp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"github.com/zarlcorp/core/pkg/zoptions"
+)
+
+// Option configures an App.
+type Option = zoptions.Option[App]
+
+// App tracks resources and tears them down in LIFO order on close.
+type App struct {
+	mu      sync.Mutex
+	once    sync.Once
+	name    string
+	closers []io.Closer
+	err     error
+}
+
+// New creates an App with the binary basename as the default name.
+// Use WithName to override.
+func New(opts ...Option) *App {
+	a := &App{
+		name: filepath.Base(os.Args[0]),
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+// Track registers a closer for cleanup. Safe for concurrent use.
+func (a *App) Track(c io.Closer) {
+	a.mu.Lock()
+	a.closers = append(a.closers, c)
+	a.mu.Unlock()
+}
+
+// Close tears down all tracked resources in LIFO order. Returns a joined
+// error if any closers fail. Safe to call multiple times — subsequent
+// calls return the same result without re-closing.
+func (a *App) Close() error {
+	a.once.Do(func() {
+		a.mu.Lock()
+		closers := a.closers
+		a.mu.Unlock()
+
+		var errs []error
+		for i := len(closers) - 1; i >= 0; i-- {
+			if err := closers[i].Close(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		a.err = errors.Join(errs...)
+	})
+	return a.err
+}
+
+// SignalContext returns a context that is cancelled when SIGINT or SIGTERM
+// is received, or when the returned cancel func is called.
+func SignalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM)
+}
+
+// CloserFunc adapts a func() error into an io.Closer.
+type CloserFunc func() error
+
+// Close calls the underlying function.
+func (f CloserFunc) Close() error { return f() }

--- a/pkg/zapp/zapp_test.go
+++ b/pkg/zapp/zapp_test.go
@@ -1,0 +1,233 @@
+package zapp_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/zarlcorp/core/pkg/zapp"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []zapp.Option
+		// we can't inspect unexported name, so we just verify it doesn't panic
+	}{
+		{
+			name: "defaults",
+			opts: nil,
+		},
+		{
+			name: "with name",
+			opts: []zapp.Option{zapp.WithName("testapp")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := zapp.New(tt.opts...)
+			if app == nil {
+				t.Fatal("New returned nil")
+			}
+		})
+	}
+}
+
+func TestDefaultName(t *testing.T) {
+	// verify New doesn't panic when reading os.Args[0]
+	want := filepath.Base(os.Args[0])
+	if want == "" {
+		t.Fatal("os.Args[0] base is empty")
+	}
+	app := zapp.New()
+	if app == nil {
+		t.Fatal("New returned nil")
+	}
+}
+
+// closer records whether Close was called and in what order.
+type closer struct {
+	id     int
+	order  *[]int
+	err    error
+}
+
+func (c *closer) Close() error {
+	*c.order = append(*c.order, c.id)
+	return c.err
+}
+
+func TestCloseLIFO(t *testing.T) {
+	var order []int
+
+	app := zapp.New()
+	app.Track(&closer{id: 1, order: &order})
+	app.Track(&closer{id: 2, order: &order})
+	app.Track(&closer{id: 3, order: &order})
+
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	want := []int{3, 2, 1}
+	if len(order) != len(want) {
+		t.Fatalf("close order = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("close order = %v, want %v", order, want)
+		}
+	}
+}
+
+func TestCloseErrors(t *testing.T) {
+	errA := errors.New("a broke")
+	errB := errors.New("b broke")
+
+	app := zapp.New()
+	app.Track(&closer{order: new([]int), err: errA})
+	app.Track(&closer{order: new([]int)})
+	app.Track(&closer{order: new([]int), err: errB})
+
+	err := app.Close()
+	if err == nil {
+		t.Fatal("Close returned nil, want error")
+	}
+
+	if !errors.Is(err, errA) {
+		t.Errorf("error should contain errA")
+	}
+	if !errors.Is(err, errB) {
+		t.Errorf("error should contain errB")
+	}
+}
+
+func TestCloseNoResources(t *testing.T) {
+	app := zapp.New()
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close with no resources: %v", err)
+	}
+}
+
+func TestCloseIdempotent(t *testing.T) {
+	var count int
+	app := zapp.New()
+	app.Track(zapp.CloserFunc(func() error {
+		count++
+		return nil
+	}))
+
+	_ = app.Close()
+	_ = app.Close()
+	_ = app.Close()
+
+	if count != 1 {
+		t.Fatalf("closer called %d times, want 1", count)
+	}
+}
+
+func TestCloseIdempotentError(t *testing.T) {
+	want := errors.New("boom")
+	app := zapp.New()
+	app.Track(zapp.CloserFunc(func() error { return want }))
+
+	err1 := app.Close()
+	err2 := app.Close()
+
+	if !errors.Is(err1, want) {
+		t.Fatalf("first Close: got %v, want %v", err1, want)
+	}
+	if !errors.Is(err2, want) {
+		t.Fatalf("second Close: got %v, want %v", err2, want)
+	}
+}
+
+func TestTrackConcurrent(t *testing.T) {
+	app := zapp.New()
+	var wg sync.WaitGroup
+	var order []int
+	var mu sync.Mutex
+
+	for i := range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			app.Track(zapp.CloserFunc(func() error {
+				mu.Lock()
+				order = append(order, i)
+				mu.Unlock()
+				return nil
+			}))
+		}()
+	}
+
+	wg.Wait()
+
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if len(order) != 100 {
+		t.Fatalf("closed %d resources, want 100", len(order))
+	}
+}
+
+func TestCloserFunc(t *testing.T) {
+	var called bool
+	var c io.Closer = zapp.CloserFunc(func() error {
+		called = true
+		return nil
+	})
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !called {
+		t.Fatal("CloserFunc was not called")
+	}
+}
+
+func TestCloserFuncError(t *testing.T) {
+	want := errors.New("cleanup failed")
+	c := zapp.CloserFunc(func() error { return want })
+
+	if got := c.Close(); !errors.Is(got, want) {
+		t.Fatalf("Close = %v, want %v", got, want)
+	}
+}
+
+func TestSignalContextCancel(t *testing.T) {
+	ctx, cancel := zapp.SignalContext(context.Background())
+	defer cancel()
+
+	// calling cancel should cancel the context
+	cancel()
+
+	select {
+	case <-ctx.Done():
+		// expected
+	default:
+		t.Fatal("context not cancelled after cancel()")
+	}
+}
+
+func TestSignalContextInheritsParent(t *testing.T) {
+	parent, parentCancel := context.WithCancel(context.Background())
+	ctx, cancel := zapp.SignalContext(parent)
+	defer cancel()
+
+	// cancelling parent should cancel the signal context
+	parentCancel()
+
+	select {
+	case <-ctx.Done():
+		// expected
+	default:
+		t.Fatal("context not cancelled when parent cancelled")
+	}
+}


### PR DESCRIPTION
Closes #1

Spec: .manager/specs/027-zapp.md

## Summary
- `App` struct with `Track`/`Close` for LIFO resource cleanup
- `SignalContext` for graceful shutdown (SIGINT/SIGTERM)
- `CloserFunc` adapter for `func() error` → `io.Closer`
- Functional options via `zoptions.Option[App]`
- 13 tests passing with race detector