### PR TITLE
029: upgrade to Go 1.26, clean up workspace

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.24.4
+go 1.26.0
 
 use (
 	./pkg/zapp

--- a/pkg/zapp/go.mod
+++ b/pkg/zapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/zarlcorp/core/pkg/zapp
 
-go 1.24.4
+go 1.26.0
 
 require github.com/zarlcorp/core/pkg/zoptions v0.0.0
 

--- a/pkg/zcache/go.mod
+++ b/pkg/zcache/go.mod
@@ -1,6 +1,6 @@
 module github.com/zarlcorp/core/pkg/zcache
 
-go 1.24.4
+go 1.26.0
 
 require (
 	github.com/redis/go-redis/v9 v9.12.1

--- a/pkg/zcrypto/doc.go
+++ b/pkg/zcrypto/doc.go
@@ -1,0 +1,2 @@
+// Package zcrypto provides encryption primitives for zarlcorp privacy tools.
+package zcrypto

--- a/pkg/zcrypto/go.mod
+++ b/pkg/zcrypto/go.mod
@@ -1,6 +1,6 @@
 module github.com/zarlcorp/core/pkg/zcrypto
 
-go 1.24.4
+go 1.26.0
 
 require golang.org/x/crypto v0.48.0
 

--- a/pkg/zfilesystem/go.mod
+++ b/pkg/zfilesystem/go.mod
@@ -1,6 +1,6 @@
 module github.com/zarlcorp/core/pkg/zfilesystem
 
-go 1.24.4
+go 1.26.0
 
 require github.com/zarlcorp/core/pkg/zsync v0.0.0
 

--- a/pkg/zoptions/go.mod
+++ b/pkg/zoptions/go.mod
@@ -1,3 +1,3 @@
 module github.com/zarlcorp/core/pkg/zoptions
 
-go 1.24.4
+go 1.26.0

--- a/pkg/zstyle/go.mod
+++ b/pkg/zstyle/go.mod
@@ -1,6 +1,6 @@
 module github.com/zarlcorp/core/pkg/zstyle
 
-go 1.24.4
+go 1.26.0
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0

--- a/pkg/zsync/go.mod
+++ b/pkg/zsync/go.mod
@@ -1,3 +1,3 @@
 module github.com/zarlcorp/core/pkg/zsync
 
-go 1.24.4
+go 1.26.0


### PR DESCRIPTION
Closes #6

## Summary
- Upgrade go.work and all 7 go.mod files from Go 1.24.4 to Go 1.26.0
- Add zcrypto doc.go placeholder so stub module compiles in workspace
- Remove `tools/goenums/` and `templates/tool/` placeholders (not needed yet)
- Run `go mod tidy` on all modules

## Verification
- All modules build cleanly
- All tests pass (zcache Redis tests fail without local Redis — pre-existing)
- `go vet` clean across all modules

Spec: `.manager/specs/029-go-upgrade.md`