### PR TITLE
031: systematic review of all shared packages

### DIFF
--- a/pkg/REVIEW.md
+++ b/pkg/REVIEW.md
@@ -1,0 +1,160 @@
+# Package Review — 031
+
+Systematic review of all 7 shared packages against zarlcorp coding standards.
+
+## Per-Package Findings
+
+### 1. zoptions (foundation, no deps)
+
+**Status:** Clean. No issues found.
+
+- Package doc with usage example: present
+- Single exported type `Option[T]` with doc comment: present
+- External test package (`zoptions_test`): yes
+- Table-driven tests: yes
+- No error handling needed (no errors in this package)
+- No dependencies beyond stdlib: correct
+
+### 2. zsync (foundation, no deps)
+
+**Findings:**
+
+- `set.go:68` — Method doc on `ZSet.Ordered` was identical wording to the package-level `Ordered` function, creating confusion about which does what.
+
+**Fixed:**
+
+- `set.go:68` — Clarified method doc to distinguish from the package-level `Ordered` function.
+
+**Notes (not fixed, by design):**
+
+- Package doc is verbose but appropriate for library code per the "Library/SDK: Comprehensive with examples" strategy.
+- `ZMap.Get` returns `ErrNotFound` (error) rather than `(V, bool)`. This is a deliberate API choice — noted but not changed per spec constraint.
+
+### 3. zcache (data layer)
+
+**Findings:**
+
+- `file.go:271` — Error message `"filesystem write failed: %w"` uses banned "failed" prefix.
+- `file.go:277` — Error message `"filesystem read failed: %w"` uses banned "failed" prefix.
+- `file.go:282` — Error message `"filesystem data integrity check failed"` uses banned "failed" prefix.
+- `redis.go:193` — Error message `"redis ping failed: %w"` uses banned "failed" prefix.
+- `redis.go:31` — `WithClient` missing doc comment.
+- `redis.go:37` — `WithPrefix` missing doc comment.
+- `redis.go:43` — `WithTTL` missing doc comment.
+- `redis.go:29` — `RedisOption` type alias missing doc comment.
+- `cache.go:40-42` — Unnecessary `var ( )` block for single `ErrNotFound` declaration; missing doc comment.
+
+**Fixed:**
+
+- `file.go` (Healthy) — Rewrote error messages: `"write health check: %w"`, `"read health check: %w"`, `"health check data mismatch"`.
+- `redis.go` (Healthy) — Rewrote error message: `"ping redis: %w"`.
+- `redis.go` — Added doc comments to `WithClient`, `WithPrefix`, `WithTTL`, `RedisOption`.
+- `cache.go` — Simplified to plain `var` declaration, added doc comment on `ErrNotFound`.
+
+**Notes (not fixed, by design):**
+
+- `file.go` `Clear()` and `Len()` type-assert to `*zfilesystem.MemFS` for optimization. This breaks the `FileSystem` interface abstraction but is a performance choice, not a bug. Changing it would alter behavior.
+- `file.go` `NewFileCache` creates a temp directory unconditionally even when options might override the filesystem. Minor waste but fixing would change constructor semantics.
+
+### 4. zfilesystem (data layer)
+
+**Findings:**
+
+- `filesystem.go:56` — Doc comment on `File` interface missing trailing period.
+- `memfs.go:66` — Doc comment on `MkdirAll` missing trailing period.
+- `memfs.go:71` — Doc comment on `OpenFile` missing trailing period.
+
+**Fixed:**
+
+- `filesystem.go:56` — Added period: `"File is a file that can be read from and written to."`
+- `memfs.go:66` — Added period to MkdirAll doc.
+- `memfs.go:71` — Added period to OpenFile doc.
+
+**Notes (not fixed, by design):**
+
+- `MemFS.ClearCacheFiles()` and `MemFS.CountCacheFiles()` are specialized methods for cache implementations that leak cache concerns into a filesystem package. However, they exist as performance optimizations and removing them would change the public API.
+
+### 5. zstyle (presentation)
+
+**Findings:**
+
+- `zstyle_test.go:1` — Uses internal test package (`package zstyle`) instead of external (`package zstyle_test`). Standards require testing the public API via external test package.
+
+**Fixed:**
+
+- `zstyle_test.go` — Converted to external test package (`package zstyle_test`), added `zstyle` import, prefixed all references with `zstyle.`.
+
+### 6. zcrypto (security)
+
+**Status:** Clean. No issues found.
+
+- Package doc with usage example: present
+- All exported functions/types have doc comments: yes
+- External test package (`zcrypto_test`): yes
+- Error messages follow direct context pattern: yes (e.g. `"create cipher: %w"`, `"generate nonce: %w"`)
+- No panics: correct
+- Erase function has appropriate best-effort caveat in doc
+- Table-driven tests where appropriate: yes
+
+### 7. zapp (top layer)
+
+**Status:** Clean. No issues found.
+
+- Package doc with usage example: present
+- All exported types/functions have doc comments: yes
+- External test package (`zapp_test`): yes
+- Error handling via `errors.Join`: correct
+- LIFO close order: tested
+- Idempotent Close via `sync.Once`: tested
+- Concurrent Track safety: tested
+- `CloserFunc` adapter with doc: present
+- `SignalContext` wrapper: clean
+
+**Notes (not fixed, by design):**
+
+- `App.name` field is set by `WithName` but never readable externally. No accessor exists. Not adding one per spec constraint (no API changes).
+
+## Cross-Package Issues
+
+### Consistency issues found and fixed
+
+| Issue | Packages | Status |
+|-------|----------|--------|
+| Error messages with "failed" prefix | zcache | Fixed |
+| Missing doc comments on exported symbols | zcache/redis.go | Fixed |
+| Internal test package instead of external | zstyle | Fixed |
+| Doc comments missing trailing periods | zfilesystem | Fixed |
+
+### Consistency issues not found (already consistent)
+
+- **Options pattern**: zoptions used consistently by zapp (via type alias) and zcache (direct import). Same pattern everywhere.
+- **Constructor naming**: `NewX()` consistently used across all packages.
+- **Error handling style**: Direct context wrapping (e.g. `"create cipher: %w"`) used everywhere except the 4 "failed" instances in zcache, now fixed.
+- **Mutex usage**: All packages use unexported `mu` field, never embedded. Correct per standards.
+- **External test packages**: All packages use `_test` suffix except zstyle, now fixed.
+- **Package docs with examples**: Present on all packages.
+- **Interface satisfaction checks**: Used in zcache (all 3 implementations), zfilesystem (both implementations), zsync (ZQueue io.Closer). Consistent pattern.
+- **Table-driven tests**: Used throughout where appropriate.
+- **File organization**: Consistent pattern of main file + implementation files + single test file (or test per implementation).
+- **Comment style**: Lowercase terse style used consistently for inline comments.
+
+## Verification
+
+All packages pass:
+- `go vet ./...` — clean
+- `go test -race ./...` — all pass
+- No remaining "failed to" / "unable to" / "could not" error prefixes
+- All exported symbols have doc comments
+- All test files use external test packages
+
+## Summary of Changes
+
+| File | Change |
+|------|--------|
+| `zcache/file.go` | Rewrote 3 error messages in Healthy() to remove "failed" prefix |
+| `zcache/redis.go` | Rewrote 1 error message in Healthy(), added 4 doc comments |
+| `zcache/cache.go` | Simplified ErrNotFound declaration, added doc comment |
+| `zfilesystem/filesystem.go` | Added period to File interface doc comment |
+| `zfilesystem/memfs.go` | Added periods to MkdirAll and OpenFile doc comments |
+| `zstyle/zstyle_test.go` | Converted to external test package |
+| `zsync/set.go` | Clarified ZSet.Ordered method doc comment |

--- a/pkg/zcache/cache.go
+++ b/pkg/zcache/cache.go
@@ -37,9 +37,8 @@ import (
 	"errors"
 )
 
-var (
-	ErrNotFound = errors.New("key not found")
-)
+// ErrNotFound is returned when a key does not exist in the cache.
+var ErrNotFound = errors.New("key not found")
 
 // Reader defines basic read operations for cache implementations.
 type Reader[K comparable, V any] interface {

--- a/pkg/zcache/file.go
+++ b/pkg/zcache/file.go
@@ -262,27 +262,22 @@ func (c *FileCache[K, V]) makeFilename(key K) string {
 
 // Healthy checks if the filesystem is accessible by testing read/write operations.
 func (c *FileCache[K, V]) Healthy() error {
-	// Test filesystem accessibility by trying to write and read a test file
 	testFile := ".health_check"
 	testData := []byte("health_check")
 
-	// Test write (0644 is standard file permissions)
 	if err := c.fs.WriteFile(testFile, testData, 0644); err != nil {
-		return fmt.Errorf("filesystem write failed: %w", err)
+		return fmt.Errorf("write health check: %w", err)
 	}
 
-	// Test read
 	data, err := c.fs.ReadFile(testFile)
 	if err != nil {
-		return fmt.Errorf("filesystem read failed: %w", err)
+		return fmt.Errorf("read health check: %w", err)
 	}
 
-	// Verify content
 	if string(data) != string(testData) {
-		return fmt.Errorf("filesystem data integrity check failed")
+		return fmt.Errorf("health check data mismatch")
 	}
 
-	// Clean up test file
 	c.fs.Remove(testFile)
 
 	return nil

--- a/pkg/zcache/redis.go
+++ b/pkg/zcache/redis.go
@@ -26,20 +26,24 @@ type RedisCache[K comparable, V any] struct {
 	ttl    time.Duration
 }
 
+// RedisOption configures a RedisCache.
 type RedisOption[K comparable, V any] = zoptions.Option[RedisCache[K, V]]
 
+// WithClient sets the Redis client for the cache.
 func WithClient[K comparable, V any](c redis.UniversalClient) RedisOption[K, V] {
 	return func(rc *RedisCache[K, V]) {
 		rc.client = c
 	}
 }
 
+// WithPrefix sets the key prefix for all cache entries.
 func WithPrefix[K comparable, V any](pre string) RedisOption[K, V] {
 	return func(rc *RedisCache[K, V]) {
 		rc.prefix = pre
 	}
 }
 
+// WithTTL sets the time-to-live for cache entries.
 func WithTTL[K comparable, V any](ttl time.Duration) RedisOption[K, V] {
 	return func(rc *RedisCache[K, V]) {
 		rc.ttl = ttl
@@ -188,9 +192,8 @@ func (c *RedisCache[K, V]) makeKey(key K) string {
 // Healthy checks if Redis is accessible by pinging it.
 func (c *RedisCache[K, V]) Healthy() error {
 	ctx := context.Background()
-	result := c.client.Ping(ctx)
-	if err := result.Err(); err != nil {
-		return fmt.Errorf("redis ping failed: %w", err)
+	if err := c.client.Ping(ctx).Err(); err != nil {
+		return fmt.Errorf("ping redis: %w", err)
 	}
 	return nil
 }

--- a/pkg/zfilesystem/filesystem.go
+++ b/pkg/zfilesystem/filesystem.go
@@ -53,7 +53,7 @@ type MkdirFS interface {
 	MkdirAll(path string, perm fs.FileMode) error
 }
 
-// File is a file that can be read from and written to
+// File is a file that can be read from and written to.
 type File interface {
 	fs.File
 	io.Writer

--- a/pkg/zfilesystem/memfs.go
+++ b/pkg/zfilesystem/memfs.go
@@ -63,12 +63,12 @@ func (mfs *MemFS) Remove(filename string) error {
 	return nil
 }
 
-// MkdirAll is a no-op for in-memory filesystem as directories are implicit
+// MkdirAll is a no-op for in-memory filesystem as directories are implicit.
 func (mfs *MemFS) MkdirAll(path string, perm fs.FileMode) error {
 	return nil
 }
 
-// OpenFile opens a file in memory with the given flags
+// OpenFile opens a file in memory with the given flags.
 func (mfs *MemFS) OpenFile(name string, flag int, perm fs.FileMode) (File, error) {
 	// For write operations, create a new file
 	if flag&(os.O_CREATE|os.O_WRONLY|os.O_RDWR) != 0 {

--- a/pkg/zstyle/zstyle_test.go
+++ b/pkg/zstyle/zstyle_test.go
@@ -1,10 +1,11 @@
-package zstyle
+package zstyle_test
 
 import (
 	"testing"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/zarlcorp/core/pkg/zstyle"
 )
 
 func TestColors(t *testing.T) {
@@ -12,15 +13,15 @@ func TestColors(t *testing.T) {
 		name  string
 		color lipgloss.Color
 	}{
-		{"Cyan", Cyan},
-		{"Orange", Orange},
-		{"Success", Success},
-		{"Error", Error},
-		{"Warning", Warning},
-		{"Info", Info},
-		{"Muted", Muted},
-		{"Subtle", Subtle},
-		{"Bright", Bright},
+		{"Cyan", zstyle.Cyan},
+		{"Orange", zstyle.Orange},
+		{"Success", zstyle.Success},
+		{"Error", zstyle.Error},
+		{"Warning", zstyle.Warning},
+		{"Info", zstyle.Info},
+		{"Muted", zstyle.Muted},
+		{"Subtle", zstyle.Subtle},
+		{"Bright", zstyle.Bright},
 	}
 
 	for _, c := range colors {
@@ -37,15 +38,15 @@ func TestStyles(t *testing.T) {
 		name  string
 		style lipgloss.Style
 	}{
-		{"Title", Title},
-		{"Subtitle", Subtitle},
-		{"Highlight", Highlight},
-		{"MutedText", MutedText},
-		{"StatusOK", StatusOK},
-		{"StatusErr", StatusErr},
-		{"StatusWarn", StatusWarn},
-		{"Border", Border},
-		{"ActiveBorder", ActiveBorder},
+		{"Title", zstyle.Title},
+		{"Subtitle", zstyle.Subtitle},
+		{"Highlight", zstyle.Highlight},
+		{"MutedText", zstyle.MutedText},
+		{"StatusOK", zstyle.StatusOK},
+		{"StatusErr", zstyle.StatusErr},
+		{"StatusWarn", zstyle.StatusWarn},
+		{"Border", zstyle.Border},
+		{"ActiveBorder", zstyle.ActiveBorder},
 	}
 
 	for _, s := range styles {
@@ -64,14 +65,14 @@ func TestKeys(t *testing.T) {
 		name    string
 		binding key.Binding
 	}{
-		{"KeyQuit", KeyQuit},
-		{"KeyHelp", KeyHelp},
-		{"KeyUp", KeyUp},
-		{"KeyDown", KeyDown},
-		{"KeyEnter", KeyEnter},
-		{"KeyBack", KeyBack},
-		{"KeyTab", KeyTab},
-		{"KeyFilter", KeyFilter},
+		{"KeyQuit", zstyle.KeyQuit},
+		{"KeyHelp", zstyle.KeyHelp},
+		{"KeyUp", zstyle.KeyUp},
+		{"KeyDown", zstyle.KeyDown},
+		{"KeyEnter", zstyle.KeyEnter},
+		{"KeyBack", zstyle.KeyBack},
+		{"KeyTab", zstyle.KeyTab},
+		{"KeyFilter", zstyle.KeyFilter},
 	}
 
 	for _, b := range bindings {

--- a/pkg/zsync/set.go
+++ b/pkg/zsync/set.go
@@ -65,12 +65,8 @@ func Ordered[T cmp.Ordered](s *ZSet[T]) []T {
 	return values
 }
 
-// Ordered returns a slice containing all values in the set sorted using the provided comparison function.
-// The comparison function should return a negative value if a < b, zero if a == b, and a positive value if a > b.
-//
-// Example:
-//
-//	values := s.Ordered(func(a, b string) int { return strings.Compare(a, b) })
+// Ordered returns a slice containing all values in the set sorted using the provided
+// comparison function. Use the package-level Ordered for cmp.Ordered types.
 func (s *ZSet[T]) Ordered(cmp func(a, b T) int) []T {
 	values := s.m.Keys()
 	slices.SortFunc(values, cmp)


### PR DESCRIPTION
Closes #15

Spec: .manager/specs/031-core-package-review.md

## Summary
- Reviewed all 7 packages (zoptions, zsync, zcache, zfilesystem, zstyle, zcrypto, zapp) against zarlcorp coding standards
- Fixed 4 banned error message prefixes in zcache
- Added missing doc comments on 4 exported symbols in zcache/redis.go
- Converted zstyle tests to external test package
- Fixed doc comment punctuation in zfilesystem
- Clarified zsync ZSet.Ordered method doc
- Created pkg/REVIEW.md with full findings

## Verification
- All 7 packages pass `go vet ./...`
- All 7 packages pass `go test -race ./...`
- No banned error prefixes remain in production code