### PR TITLE
035: add age-format encryption to zcrypto

### DIFF
--- a/pkg/zcrypto/aes.go
+++ b/pkg/zcrypto/aes.go
@@ -1,33 +1,3 @@
-// Package zcrypto provides encryption primitives for zarlcorp privacy tools.
-//
-// It composes proven Go stdlib and x/crypto primitives — no custom cryptography.
-// All error paths return errors; the package never panics.
-//
-// # Features
-//
-//   - AES-256-GCM symmetric encryption
-//   - Argon2id password-based key derivation
-//   - HKDF-SHA256 key expansion
-//   - Cryptographic random generation
-//   - Secure memory erasure
-//   - File encryption/decryption helpers
-//
-// # Usage
-//
-//	key, salt, err := zcrypto.DeriveKey([]byte("passphrase"), nil)
-//	if err != nil {
-//	    // handle error
-//	}
-//
-//	ciphertext, err := zcrypto.Encrypt(key, []byte("secret"))
-//	if err != nil {
-//	    // handle error
-//	}
-//
-//	plaintext, err := zcrypto.Decrypt(key, ciphertext)
-//	if err != nil {
-//	    // handle error
-//	}
 package zcrypto
 
 import (

--- a/pkg/zcrypto/age.go
+++ b/pkg/zcrypto/age.go
@@ -1,0 +1,102 @@
+package zcrypto
+
+import (
+	"fmt"
+	"io"
+
+	"filippo.io/age"
+)
+
+// EncryptAge encrypts src to dst using age's scrypt recipient format.
+// Output is compatible with `age -d -p`.
+func EncryptAge(password string, src io.Reader, dst io.Writer) error {
+	r, err := age.NewScryptRecipient(password)
+	if err != nil {
+		return fmt.Errorf("age encrypt: %w", err)
+	}
+
+	w, err := age.Encrypt(dst, r)
+	if err != nil {
+		return fmt.Errorf("age encrypt: %w", err)
+	}
+
+	if _, err := io.Copy(w, src); err != nil {
+		return fmt.Errorf("age encrypt: %w", err)
+	}
+
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("age encrypt: %w", err)
+	}
+
+	return nil
+}
+
+// DecryptAge decrypts an age-encrypted stream using a password.
+// Input from `age -e -p` is accepted.
+func DecryptAge(password string, src io.Reader, dst io.Writer) error {
+	id, err := age.NewScryptIdentity(password)
+	if err != nil {
+		return fmt.Errorf("age decrypt: %w", err)
+	}
+
+	r, err := age.Decrypt(src, id)
+	if err != nil {
+		return fmt.Errorf("age decrypt: %w", err)
+	}
+
+	if _, err := io.Copy(dst, r); err != nil {
+		return fmt.Errorf("age decrypt: %w", err)
+	}
+
+	return nil
+}
+
+// EncryptAgeKey encrypts src to dst for one or more age X25519 public key recipients.
+// Each recipient string must be a valid age public key (e.g. "age1...").
+// Output is compatible with `age -r <pubkey>`.
+func EncryptAgeKey(recipients []string, src io.Reader, dst io.Writer) error {
+	parsed := make([]age.Recipient, 0, len(recipients))
+	for _, s := range recipients {
+		r, err := age.ParseX25519Recipient(s)
+		if err != nil {
+			return fmt.Errorf("age encrypt: parse recipient: %w", err)
+		}
+		parsed = append(parsed, r)
+	}
+
+	w, err := age.Encrypt(dst, parsed...)
+	if err != nil {
+		return fmt.Errorf("age encrypt: %w", err)
+	}
+
+	if _, err := io.Copy(w, src); err != nil {
+		return fmt.Errorf("age encrypt: %w", err)
+	}
+
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("age encrypt: %w", err)
+	}
+
+	return nil
+}
+
+// DecryptAgeKey decrypts an age-encrypted stream using an X25519 identity (private key).
+// The identity string must be a valid age secret key (e.g. "AGE-SECRET-KEY-1...").
+// Compatible with files encrypted via `age -r <pubkey>`.
+func DecryptAgeKey(identity string, src io.Reader, dst io.Writer) error {
+	id, err := age.ParseX25519Identity(identity)
+	if err != nil {
+		return fmt.Errorf("age decrypt: parse identity: %w", err)
+	}
+
+	r, err := age.Decrypt(src, id)
+	if err != nil {
+		return fmt.Errorf("age decrypt: %w", err)
+	}
+
+	if _, err := io.Copy(dst, r); err != nil {
+		return fmt.Errorf("age decrypt: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/zcrypto/age_test.go
+++ b/pkg/zcrypto/age_test.go
@@ -1,0 +1,312 @@
+package zcrypto_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+
+	"github.com/zarlcorp/core/pkg/zcrypto"
+)
+
+func TestEncryptAgeDecryptAge(t *testing.T) {
+	tests := []struct {
+		name      string
+		password  string
+		plaintext string
+	}{
+		{name: "basic round trip", password: "hunter2", plaintext: "hello, age"},
+		{name: "empty plaintext", password: "pass", plaintext: ""},
+		{name: "long password", password: strings.Repeat("a", 1024), plaintext: "data"},
+		{name: "binary-like data", password: "pw", plaintext: "\x00\xff\x01\xfe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var encrypted bytes.Buffer
+			if err := zcrypto.EncryptAge(tt.password, strings.NewReader(tt.plaintext), &encrypted); err != nil {
+				t.Fatalf("encrypt: %v", err)
+			}
+
+			var decrypted bytes.Buffer
+			if err := zcrypto.DecryptAge(tt.password, &encrypted, &decrypted); err != nil {
+				t.Fatalf("decrypt: %v", err)
+			}
+
+			if decrypted.String() != tt.plaintext {
+				t.Fatalf("got %q, want %q", decrypted.String(), tt.plaintext)
+			}
+		})
+	}
+}
+
+func TestDecryptAgeWrongPassword(t *testing.T) {
+	var encrypted bytes.Buffer
+	if err := zcrypto.EncryptAge("correct", strings.NewReader("secret"), &encrypted); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	var decrypted bytes.Buffer
+	err := zcrypto.DecryptAge("wrong", bytes.NewReader(encrypted.Bytes()), &decrypted)
+	if err == nil {
+		t.Fatal("expected error decrypting with wrong password")
+	}
+}
+
+func TestDecryptAgeInvalidInput(t *testing.T) {
+	var decrypted bytes.Buffer
+	err := zcrypto.DecryptAge("pw", strings.NewReader("not an age file"), &decrypted)
+	if err == nil {
+		t.Fatal("expected error decrypting invalid input")
+	}
+}
+
+func TestEncryptAgeKeyDecryptAgeKey(t *testing.T) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	pubkey := id.Recipient().String()
+	privkey := id.String()
+
+	tests := []struct {
+		name      string
+		plaintext string
+	}{
+		{name: "basic round trip", plaintext: "hello, age keys"},
+		{name: "empty plaintext", plaintext: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var encrypted bytes.Buffer
+			if err := zcrypto.EncryptAgeKey([]string{pubkey}, strings.NewReader(tt.plaintext), &encrypted); err != nil {
+				t.Fatalf("encrypt: %v", err)
+			}
+
+			var decrypted bytes.Buffer
+			if err := zcrypto.DecryptAgeKey(privkey, &encrypted, &decrypted); err != nil {
+				t.Fatalf("decrypt: %v", err)
+			}
+
+			if decrypted.String() != tt.plaintext {
+				t.Fatalf("got %q, want %q", decrypted.String(), tt.plaintext)
+			}
+		})
+	}
+}
+
+func TestEncryptAgeKeyMultipleRecipients(t *testing.T) {
+	id1, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity 1: %v", err)
+	}
+
+	id2, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity 2: %v", err)
+	}
+
+	recipients := []string{
+		id1.Recipient().String(),
+		id2.Recipient().String(),
+	}
+
+	plaintext := "shared secret"
+
+	var encrypted bytes.Buffer
+	if err := zcrypto.EncryptAgeKey(recipients, strings.NewReader(plaintext), &encrypted); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	// both recipients should be able to decrypt
+	for i, id := range []*age.X25519Identity{id1, id2} {
+		var decrypted bytes.Buffer
+		if err := zcrypto.DecryptAgeKey(id.String(), bytes.NewReader(encrypted.Bytes()), &decrypted); err != nil {
+			t.Fatalf("decrypt with identity %d: %v", i+1, err)
+		}
+		if decrypted.String() != plaintext {
+			t.Fatalf("identity %d: got %q, want %q", i+1, decrypted.String(), plaintext)
+		}
+	}
+}
+
+func TestDecryptAgeKeyWrongIdentity(t *testing.T) {
+	id1, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity 1: %v", err)
+	}
+
+	id2, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity 2: %v", err)
+	}
+
+	var encrypted bytes.Buffer
+	if err := zcrypto.EncryptAgeKey([]string{id1.Recipient().String()}, strings.NewReader("secret"), &encrypted); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	var decrypted bytes.Buffer
+	err = zcrypto.DecryptAgeKey(id2.String(), bytes.NewReader(encrypted.Bytes()), &decrypted)
+	if err == nil {
+		t.Fatal("expected error decrypting with wrong identity")
+	}
+}
+
+func TestEncryptAgeKeyInvalidRecipient(t *testing.T) {
+	err := zcrypto.EncryptAgeKey([]string{"not-a-key"}, strings.NewReader("data"), &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error for invalid recipient")
+	}
+}
+
+func TestDecryptAgeKeyInvalidIdentity(t *testing.T) {
+	err := zcrypto.DecryptAgeKey("not-a-key", strings.NewReader("data"), &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error for invalid identity")
+	}
+}
+
+// interop tests require the age CLI — skip when unavailable
+
+func ageCLI(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("age")
+	if err != nil {
+		t.Skip("age CLI not found, skipping interop test")
+	}
+	return path
+}
+
+func TestInteropEncryptZcryptoDecryptAgeCLI(t *testing.T) {
+	ageBin := ageCLI(t)
+
+	password := "interop-test-password"
+	plaintext := "encrypted by zcrypto, decrypted by age CLI"
+
+	var encrypted bytes.Buffer
+	if err := zcrypto.EncryptAge(password, strings.NewReader(plaintext), &encrypted); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	cmd := exec.Command(ageBin, "-d")
+	cmd.Stdin = &encrypted
+	cmd.Env = append(cmd.Environ(), "AGE_PASSPHRASE="+password)
+
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("age -d: %v\nstderr: %s", err, ee.Stderr)
+		}
+		t.Fatalf("age -d: %v", err)
+	}
+
+	if string(out) != plaintext {
+		t.Fatalf("age CLI decrypted %q, want %q", string(out), plaintext)
+	}
+}
+
+func TestInteropEncryptAgeCLIDecryptZcrypto(t *testing.T) {
+	ageBin := ageCLI(t)
+
+	password := "interop-test-password"
+	plaintext := "encrypted by age CLI, decrypted by zcrypto"
+
+	cmd := exec.Command(ageBin, "-e", "-p")
+	cmd.Stdin = strings.NewReader(plaintext)
+	cmd.Env = append(cmd.Environ(), "AGE_PASSPHRASE="+password)
+
+	encrypted, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("age -e -p: %v\nstderr: %s", err, ee.Stderr)
+		}
+		t.Fatalf("age -e -p: %v", err)
+	}
+
+	var decrypted bytes.Buffer
+	if err := zcrypto.DecryptAge(password, bytes.NewReader(encrypted), &decrypted); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	if decrypted.String() != plaintext {
+		t.Fatalf("got %q, want %q", decrypted.String(), plaintext)
+	}
+}
+
+func TestInteropKeyEncryptZcryptoDecryptAgeCLI(t *testing.T) {
+	ageBin := ageCLI(t)
+
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	plaintext := "key-encrypted by zcrypto"
+
+	var encrypted bytes.Buffer
+	if err := zcrypto.EncryptAgeKey([]string{id.Recipient().String()}, strings.NewReader(plaintext), &encrypted); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	// write identity to a temp file for the age CLI
+	identityFile := t.TempDir() + "/identity"
+	if err := writeFile(identityFile, []byte(id.String())); err != nil {
+		t.Fatalf("write identity file: %v", err)
+	}
+
+	cmd := exec.Command(ageBin, "-d", "-i", identityFile)
+	cmd.Stdin = &encrypted
+
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("age -d -i: %v\nstderr: %s", err, ee.Stderr)
+		}
+		t.Fatalf("age -d -i: %v", err)
+	}
+
+	if string(out) != plaintext {
+		t.Fatalf("age CLI decrypted %q, want %q", string(out), plaintext)
+	}
+}
+
+func TestInteropKeyEncryptAgeCLIDecryptZcrypto(t *testing.T) {
+	ageBin := ageCLI(t)
+
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	plaintext := "key-encrypted by age CLI"
+
+	cmd := exec.Command(ageBin, "-e", "-r", id.Recipient().String())
+	cmd.Stdin = strings.NewReader(plaintext)
+
+	encrypted, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("age -e -r: %v\nstderr: %s", err, ee.Stderr)
+		}
+		t.Fatalf("age -e -r: %v", err)
+	}
+
+	var decrypted bytes.Buffer
+	if err := zcrypto.DecryptAgeKey(id.String(), bytes.NewReader(encrypted), &decrypted); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	if decrypted.String() != plaintext {
+		t.Fatalf("got %q, want %q", decrypted.String(), plaintext)
+	}
+}
+
+func writeFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0o600)
+}

--- a/pkg/zcrypto/doc.go
+++ b/pkg/zcrypto/doc.go
@@ -1,2 +1,61 @@
 // Package zcrypto provides encryption primitives for zarlcorp privacy tools.
+//
+// It composes proven Go stdlib and x/crypto primitives — no custom cryptography.
+// All error paths return errors; the package never panics.
+//
+// # Features
+//
+//   - AES-256-GCM symmetric encryption
+//   - Argon2id password-based key derivation
+//   - HKDF-SHA256 key expansion
+//   - Cryptographic random generation
+//   - Secure memory erasure
+//   - File encryption/decryption helpers
+//   - age-compatible password and key-based encryption
+//
+// # AES-256-GCM
+//
+//	key, salt, err := zcrypto.DeriveKey([]byte("passphrase"), nil)
+//	if err != nil {
+//	    // handle error
+//	}
+//
+//	ciphertext, err := zcrypto.Encrypt(key, []byte("secret"))
+//	if err != nil {
+//	    // handle error
+//	}
+//
+//	plaintext, err := zcrypto.Decrypt(key, ciphertext)
+//	if err != nil {
+//	    // handle error
+//	}
+//
+// # Age Password Encryption
+//
+// Password-based age encryption produces output compatible with the age CLI.
+//
+//	err := zcrypto.EncryptAge("passphrase", src, dst)
+//	if err != nil {
+//	    // handle error
+//	}
+//
+//	err = zcrypto.DecryptAge("passphrase", src, dst)
+//	if err != nil {
+//	    // handle error
+//	}
+//
+// # Age Key Encryption
+//
+// Key-based age encryption uses X25519 public keys and is compatible with
+// age -r and age -i.
+//
+//	err := zcrypto.EncryptAgeKey([]string{"age1..."}, src, dst)
+//	if err != nil {
+//	    // handle error
+//	}
+//
+//	err = zcrypto.DecryptAgeKey("AGE-SECRET-KEY-1...", src, dst)
+//	if err != nil {
+//	    // handle error
+//	}
 package zcrypto

--- a/pkg/zcrypto/go.mod
+++ b/pkg/zcrypto/go.mod
@@ -2,6 +2,12 @@ module github.com/zarlcorp/core/pkg/zcrypto
 
 go 1.26.0
 
-require golang.org/x/crypto v0.48.0
+require (
+	filippo.io/age v1.3.1
+	golang.org/x/crypto v0.48.0
+)
 
-require golang.org/x/sys v0.41.0 // indirect
+require (
+	filippo.io/hpke v0.4.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
+)

--- a/pkg/zcrypto/go.sum
+++ b/pkg/zcrypto/go.sum
@@ -1,3 +1,9 @@
+c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd h1:ZLsPO6WdZ5zatV4UfVpr7oAwLGRZ+sebTUruuM4Ra3M=
+c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd/go.mod h1:SrHC2C7r5GkDk8R+NFVzYy/sdj0Ypg9htaPXQq5Cqeo=
+filippo.io/age v1.3.1 h1:hbzdQOJkuaMEpRCLSN1/C5DX74RPcNCk6oqhKMXmZi0=
+filippo.io/age v1.3.1/go.mod h1:EZorDTYUxt836i3zdori5IJX/v2Lj6kWFU0cfh6C0D4=
+filippo.io/hpke v0.4.0 h1:p575VVQ6ted4pL+it6M00V/f2qTZITO0zgmdKCkd5+A=
+filippo.io/hpke v0.4.0/go.mod h1:EmAN849/P3qdeK+PCMkDpDm83vRHM5cDipBJ8xbQLVY=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=


### PR DESCRIPTION
## Summary
- Add password-based age encryption (EncryptAge/DecryptAge) via scrypt
- Add key-based age encryption (EncryptAgeKey/DecryptAgeKey) via X25519
- All functions are streaming (io.Reader/io.Writer) — no full-file buffering
- Interop tests validate compatibility with `age` CLI (skip gracefully when unavailable)
- New dependency: `filippo.io/age v1.3.1`

Closes #21

Spec: `.manager/specs/035-zcrypto-age.md`

## Test plan
- [x] Round-trip tests for password-based and key-based encryption
- [x] Wrong password/key rejection tests
- [x] Invalid input handling
- [x] Multiple-recipient key encryption
- [x] CLI interop tests (skip when `age` not installed)
- [x] All existing zcrypto tests still pass
- [x] Race detector enabled
- [x] golangci-lint clean