### PR TITLE
fix inter-module go.mod references for external consumers

### DIFF
--- a/pkg/zapp/go.mod
+++ b/pkg/zapp/go.mod
@@ -2,6 +2,4 @@ module github.com/zarlcorp/core/pkg/zapp
 
 go 1.26.0
 
-require github.com/zarlcorp/core/pkg/zoptions v0.0.0
-
-replace github.com/zarlcorp/core/pkg/zoptions => ../zoptions
+require github.com/zarlcorp/core/pkg/zoptions v0.1.0

--- a/pkg/zapp/go.sum
+++ b/pkg/zapp/go.sum
@@ -1,0 +1,2 @@
+github.com/zarlcorp/core/pkg/zoptions v0.1.0 h1:/WgBilZ7tXGfqcq76nd8BOQv/JRaCsj7TLOXE5JNh7s=
+github.com/zarlcorp/core/pkg/zoptions v0.1.0/go.mod h1:JfZ/LnI9wEsmzXpSwmrFRIXCZARt3s9XMUt7UsSbo1s=

--- a/pkg/zcache/go.mod
+++ b/pkg/zcache/go.mod
@@ -4,18 +4,12 @@ go 1.26.0
 
 require (
 	github.com/redis/go-redis/v9 v9.12.1
-	github.com/zarlcorp/core/pkg/zfilesystem v0.0.0
-	github.com/zarlcorp/core/pkg/zoptions v0.0.0
+	github.com/zarlcorp/core/pkg/zfilesystem v0.1.0
+	github.com/zarlcorp/core/pkg/zoptions v0.1.0
 )
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/zarlcorp/core/pkg/zsync v0.0.0 // indirect
-)
-
-replace (
-	github.com/zarlcorp/core/pkg/zfilesystem => ../zfilesystem
-	github.com/zarlcorp/core/pkg/zoptions => ../zoptions
-	github.com/zarlcorp/core/pkg/zsync => ../zsync
+	github.com/zarlcorp/core/pkg/zsync v0.1.0 // indirect
 )

--- a/pkg/zcache/go.sum
+++ b/pkg/zcache/go.sum
@@ -8,3 +8,9 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/redis/go-redis/v9 v9.12.1 h1:k5iquqv27aBtnTm2tIkROUDp8JBXhXZIVu1InSgvovg=
 github.com/redis/go-redis/v9 v9.12.1/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
+github.com/zarlcorp/core/pkg/zfilesystem v0.1.0 h1:8jJ1nY3OFwNmqOIchPq1+WiRuYDUlHqG1WKRcGiWB0c=
+github.com/zarlcorp/core/pkg/zfilesystem v0.1.0/go.mod h1:6XxQ4wSlFNHzZSfM+YxKysrlTAUHcdQeIfCs9ebc2Zc=
+github.com/zarlcorp/core/pkg/zoptions v0.1.0 h1:/WgBilZ7tXGfqcq76nd8BOQv/JRaCsj7TLOXE5JNh7s=
+github.com/zarlcorp/core/pkg/zoptions v0.1.0/go.mod h1:JfZ/LnI9wEsmzXpSwmrFRIXCZARt3s9XMUt7UsSbo1s=
+github.com/zarlcorp/core/pkg/zsync v0.1.0 h1:XR/HFKu+mK/4XkEAkTrcaiCOahyWxqBS5l6XhwgZJwI=
+github.com/zarlcorp/core/pkg/zsync v0.1.0/go.mod h1:uPnywnOHOaotnMrrSzPBeziPPZgtS0aEMZL1XcnrcO4=

--- a/pkg/zfilesystem/go.mod
+++ b/pkg/zfilesystem/go.mod
@@ -2,6 +2,4 @@ module github.com/zarlcorp/core/pkg/zfilesystem
 
 go 1.26.0
 
-require github.com/zarlcorp/core/pkg/zsync v0.0.0
-
-replace github.com/zarlcorp/core/pkg/zsync => ../zsync
+require github.com/zarlcorp/core/pkg/zsync v0.1.0

--- a/pkg/zfilesystem/go.sum
+++ b/pkg/zfilesystem/go.sum
@@ -1,0 +1,2 @@
+github.com/zarlcorp/core/pkg/zsync v0.1.0 h1:XR/HFKu+mK/4XkEAkTrcaiCOahyWxqBS5l6XhwgZJwI=
+github.com/zarlcorp/core/pkg/zsync v0.1.0/go.mod h1:uPnywnOHOaotnMrrSzPBeziPPZgtS0aEMZL1XcnrcO4=


### PR DESCRIPTION
## Summary
- Replace `v0.0.0` + `replace` directives with proper `v0.1.0` references in zapp, zfilesystem, and zcache go.mod files
- The `replace` directives only work within the `go.work` workspace and break external consumers (zburn, zvault, zshield)
- `go.work` still handles local resolution during development

## Test plan
- [x] `go mod tidy` succeeds for all three modules
- [x] `go test` passes for zapp and zfilesystem
- [x] zcache tests pass (Redis tests skip without Redis)