### PR TITLE
058: zstyle Catppuccin Mocha palette

### DIFF
--- a/pkg/zstyle/colors.go
+++ b/pkg/zstyle/colors.go
@@ -4,36 +4,96 @@
 // keybinding constants. Every zarlcorp TUI tool imports zstyle so they share
 // the same look and feel.
 //
-// zstyle assumes a dark terminal background and never sets background colors
-// on main content areas.
+// The palette is Catppuccin Mocha — warm pastels on dark backgrounds, designed
+// for the riced/unixporn aesthetic: rounded borders, floating containers,
+// monospaced everything.
 //
 // # Usage
 //
 //	import "github.com/zarlcorp/core/pkg/zstyle"
 //
 //	fmt.Println(zstyle.Title.Render("My Tool"))
-//	fmt.Println(zstyle.StatusOK.Render("✓ done"))
+//	fmt.Println(zstyle.StatusOK.Render("done"))
 package zstyle
 
 import "github.com/charmbracelet/lipgloss"
 
-// core brand colors
+// catppuccin mocha base colors
 var (
-	Cyan   = lipgloss.Color("#00E5FF") // primary — headings, active elements, highlights
-	Orange = lipgloss.Color("#FF6E40") // accent — calls to action, selected items, emphasis
+	Base     = lipgloss.Color("#1e1e2e") // primary background
+	Mantle   = lipgloss.Color("#181825") // darker background
+	Crust    = lipgloss.Color("#11111b") // darkest background
+	Surface0 = lipgloss.Color("#313244") // elevated surface
+	Surface1 = lipgloss.Color("#45475a") // borders, separators
+	Surface2 = lipgloss.Color("#585b70") // inactive elements
+	Overlay0 = lipgloss.Color("#6c7086") // muted text
+	Overlay1 = lipgloss.Color("#7f849c") // secondary text
+	Overlay2 = lipgloss.Color("#9399b2")
+	Subtext0 = lipgloss.Color("#a6adc8")
+	Subtext1 = lipgloss.Color("#bac2de")
+	Text     = lipgloss.Color("#cdd6f4") // primary text
 )
 
-// semantic colors
+// catppuccin mocha accent colors
 var (
-	Success = lipgloss.Color("#69F0AE") // green — completed, passed, ok
-	Error   = lipgloss.Color("#FF5252") // red — errors, failures, destructive actions
-	Warning = lipgloss.Color("#FFD740") // amber — warnings, caution
-	Info    = lipgloss.Color("#40C4FF") // light blue — informational
+	Rosewater = lipgloss.Color("#f5e0dc")
+	Flamingo  = lipgloss.Color("#f2cdcd")
+	Pink      = lipgloss.Color("#f5c2e7")
+	Mauve     = lipgloss.Color("#cba6f7")
+	Red       = lipgloss.Color("#f38ba8")
+	Maroon    = lipgloss.Color("#eba0ac")
+	Peach     = lipgloss.Color("#fab387")
+	Yellow    = lipgloss.Color("#f9e2af")
+	Green     = lipgloss.Color("#a6e3a1")
+	Teal      = lipgloss.Color("#94e2d5")
+	Sky       = lipgloss.Color("#89dceb")
+	Sapphire  = lipgloss.Color("#74c7ec")
+	Blue      = lipgloss.Color("#89b4fa")
+	Lavender  = lipgloss.Color("#b4befe")
 )
 
-// neutral tones
+// semantic colors mapped to catppuccin accents
 var (
-	Muted  = lipgloss.Color("#78909C") // grey-blue — secondary text, timestamps, metadata
-	Subtle = lipgloss.Color("#37474F") // dark grey — borders, separators, inactive elements
-	Bright = lipgloss.Color("#ECEFF1") // near-white — primary text when emphasis needed
+	Success = Green
+	Error   = Red
+	Warning = Yellow
+	Info    = Blue
 )
+
+// per-tool accent colors
+var (
+	ZburnAccent   = Peach    // warm — fire, burning
+	ZvaultAccent  = Mauve    // regal — vaults, secrets
+	ZshieldAccent = Teal     // protective — shields, safety
+)
+
+// CSSVariables exports the full catppuccin mocha palette as CSS custom properties.
+const CSSVariables = `:root {
+  --ctp-base: #1e1e2e;
+  --ctp-mantle: #181825;
+  --ctp-crust: #11111b;
+  --ctp-surface0: #313244;
+  --ctp-surface1: #45475a;
+  --ctp-surface2: #585b70;
+  --ctp-overlay0: #6c7086;
+  --ctp-overlay1: #7f849c;
+  --ctp-overlay2: #9399b2;
+  --ctp-subtext0: #a6adc8;
+  --ctp-subtext1: #bac2de;
+  --ctp-text: #cdd6f4;
+  --ctp-rosewater: #f5e0dc;
+  --ctp-flamingo: #f2cdcd;
+  --ctp-pink: #f5c2e7;
+  --ctp-mauve: #cba6f7;
+  --ctp-red: #f38ba8;
+  --ctp-maroon: #eba0ac;
+  --ctp-peach: #fab387;
+  --ctp-yellow: #f9e2af;
+  --ctp-green: #a6e3a1;
+  --ctp-teal: #94e2d5;
+  --ctp-sky: #89dceb;
+  --ctp-sapphire: #74c7ec;
+  --ctp-blue: #89b4fa;
+  --ctp-lavender: #b4befe;
+}
+`

--- a/pkg/zstyle/styles.go
+++ b/pkg/zstyle/styles.go
@@ -4,10 +4,10 @@ import "github.com/charmbracelet/lipgloss"
 
 // text styles
 var (
-	Title     = lipgloss.NewStyle().Bold(true).Foreground(Cyan)
-	Subtitle  = lipgloss.NewStyle().Bold(true).Foreground(Muted)
-	Highlight = lipgloss.NewStyle().Foreground(Orange)
-	MutedText = lipgloss.NewStyle().Foreground(Muted)
+	Title     = lipgloss.NewStyle().Bold(true).Foreground(Lavender)
+	Subtitle  = lipgloss.NewStyle().Bold(true).Foreground(Subtext1)
+	Highlight = lipgloss.NewStyle().Foreground(Peach)
+	MutedText = lipgloss.NewStyle().Foreground(Overlay1)
 )
 
 // status indicators
@@ -19,6 +19,6 @@ var (
 
 // structural styles
 var (
-	Border       = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(Subtle)
-	ActiveBorder = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(Cyan)
+	Border       = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(Surface1)
+	ActiveBorder = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(Lavender)
 )

--- a/pkg/zstyle/zstyle_test.go
+++ b/pkg/zstyle/zstyle_test.go
@@ -1,6 +1,7 @@
 package zstyle_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -8,26 +9,102 @@ import (
 	"github.com/zarlcorp/core/pkg/zstyle"
 )
 
-func TestColors(t *testing.T) {
+func TestBaseColors(t *testing.T) {
 	colors := []struct {
-		name  string
+		name string
 		color lipgloss.Color
+		hex  string
 	}{
-		{"Cyan", zstyle.Cyan},
-		{"Orange", zstyle.Orange},
-		{"Success", zstyle.Success},
-		{"Error", zstyle.Error},
-		{"Warning", zstyle.Warning},
-		{"Info", zstyle.Info},
-		{"Muted", zstyle.Muted},
-		{"Subtle", zstyle.Subtle},
-		{"Bright", zstyle.Bright},
+		{"Base", zstyle.Base, "#1e1e2e"},
+		{"Mantle", zstyle.Mantle, "#181825"},
+		{"Crust", zstyle.Crust, "#11111b"},
+		{"Surface0", zstyle.Surface0, "#313244"},
+		{"Surface1", zstyle.Surface1, "#45475a"},
+		{"Surface2", zstyle.Surface2, "#585b70"},
+		{"Overlay0", zstyle.Overlay0, "#6c7086"},
+		{"Overlay1", zstyle.Overlay1, "#7f849c"},
+		{"Overlay2", zstyle.Overlay2, "#9399b2"},
+		{"Subtext0", zstyle.Subtext0, "#a6adc8"},
+		{"Subtext1", zstyle.Subtext1, "#bac2de"},
+		{"Text", zstyle.Text, "#cdd6f4"},
 	}
 
 	for _, c := range colors {
 		t.Run(c.name, func(t *testing.T) {
-			if c.color == "" {
-				t.Errorf("color %s is empty", c.name)
+			if string(c.color) != c.hex {
+				t.Errorf("got %s, want %s", c.color, c.hex)
+			}
+		})
+	}
+}
+
+func TestAccentColors(t *testing.T) {
+	colors := []struct {
+		name  string
+		color lipgloss.Color
+		hex   string
+	}{
+		{"Rosewater", zstyle.Rosewater, "#f5e0dc"},
+		{"Flamingo", zstyle.Flamingo, "#f2cdcd"},
+		{"Pink", zstyle.Pink, "#f5c2e7"},
+		{"Mauve", zstyle.Mauve, "#cba6f7"},
+		{"Red", zstyle.Red, "#f38ba8"},
+		{"Maroon", zstyle.Maroon, "#eba0ac"},
+		{"Peach", zstyle.Peach, "#fab387"},
+		{"Yellow", zstyle.Yellow, "#f9e2af"},
+		{"Green", zstyle.Green, "#a6e3a1"},
+		{"Teal", zstyle.Teal, "#94e2d5"},
+		{"Sky", zstyle.Sky, "#89dceb"},
+		{"Sapphire", zstyle.Sapphire, "#74c7ec"},
+		{"Blue", zstyle.Blue, "#89b4fa"},
+		{"Lavender", zstyle.Lavender, "#b4befe"},
+	}
+
+	for _, c := range colors {
+		t.Run(c.name, func(t *testing.T) {
+			if string(c.color) != c.hex {
+				t.Errorf("got %s, want %s", c.color, c.hex)
+			}
+		})
+	}
+}
+
+func TestSemanticColors(t *testing.T) {
+	tests := []struct {
+		name     string
+		semantic lipgloss.Color
+		accent   lipgloss.Color
+	}{
+		{"Success=Green", zstyle.Success, zstyle.Green},
+		{"Error=Red", zstyle.Error, zstyle.Red},
+		{"Warning=Yellow", zstyle.Warning, zstyle.Yellow},
+		{"Info=Blue", zstyle.Info, zstyle.Blue},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.semantic != tt.accent {
+				t.Errorf("got %s, want %s", tt.semantic, tt.accent)
+			}
+		})
+	}
+}
+
+func TestToolAccents(t *testing.T) {
+	tests := []struct {
+		name   string
+		accent lipgloss.Color
+		want   lipgloss.Color
+	}{
+		{"ZburnAccent=Peach", zstyle.ZburnAccent, zstyle.Peach},
+		{"ZvaultAccent=Mauve", zstyle.ZvaultAccent, zstyle.Mauve},
+		{"ZshieldAccent=Teal", zstyle.ZshieldAccent, zstyle.Teal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.accent != tt.want {
+				t.Errorf("got %s, want %s", tt.accent, tt.want)
 			}
 		})
 	}
@@ -51,12 +128,34 @@ func TestStyles(t *testing.T) {
 
 	for _, s := range styles {
 		t.Run(s.name, func(t *testing.T) {
-			// verify rendering does not panic
 			got := s.style.Render("test")
 			if got == "" {
 				t.Errorf("style %s rendered empty string", s.name)
 			}
 		})
+	}
+}
+
+func TestCSSVariables(t *testing.T) {
+	required := []string{
+		"--ctp-base: #1e1e2e",
+		"--ctp-mantle: #181825",
+		"--ctp-crust: #11111b",
+		"--ctp-text: #cdd6f4",
+		"--ctp-rosewater: #f5e0dc",
+		"--ctp-lavender: #b4befe",
+		"--ctp-peach: #fab387",
+		"--ctp-green: #a6e3a1",
+	}
+
+	for _, want := range required {
+		if !strings.Contains(zstyle.CSSVariables, want) {
+			t.Errorf("CSSVariables missing %q", want)
+		}
+	}
+
+	if !strings.HasPrefix(zstyle.CSSVariables, ":root {") {
+		t.Error("CSSVariables should start with :root {")
 	}
 }
 


### PR DESCRIPTION
Closes #33

Replaces the ad-hoc color palette with full Catppuccin Mocha. Adds per-tool accent colors (zburn=Peach, zvault=Mauve, zshield=Teal), semantic mappings, and CSS export helper.

Spec: .manager/specs/058-zstyle-catppuccin.md