### PR TITLE
081: add zarlcorp ASCII logo to zstyle

### DIFF
--- a/pkg/zstyle/logo.go
+++ b/pkg/zstyle/logo.go
@@ -1,0 +1,15 @@
+package zstyle
+
+import "github.com/charmbracelet/lipgloss"
+
+// Logo is the zarlcorp ASCII art wordmark for TUI splash screens.
+// uses box-drawing characters for a clean, minimal look.
+const Logo = "" +
+	"┌─┐┌─┐┬─┐┬  ┌─┐┌─┐┬─┐┌─┐\n" +
+	"┌─┘├─┤├┬┘│  │  │ │├┬┘├─┘\n" +
+	"└─┘┴ ┴┴└─┴─┘└─┘└─┘┴└─┴  "
+
+// StyledLogo returns the logo rendered with the given lipgloss style.
+func StyledLogo(s lipgloss.Style) string {
+	return s.Render(Logo)
+}

--- a/pkg/zstyle/logo_test.go
+++ b/pkg/zstyle/logo_test.go
@@ -1,0 +1,41 @@
+package zstyle_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zarlcorp/core/pkg/zstyle"
+)
+
+func TestLogo(t *testing.T) {
+	t.Run("not empty", func(t *testing.T) {
+		if zstyle.Logo == "" {
+			t.Error("Logo is empty")
+		}
+	})
+
+	t.Run("fits 80 columns", func(t *testing.T) {
+		for i, line := range strings.Split(zstyle.Logo, "\n") {
+			// count runes, not bytes — logo uses multibyte box-drawing chars
+			n := 0
+			for range line {
+				n++
+			}
+			if n > 80 {
+				t.Errorf("line %d is %d runes wide, want <= 80", i, n)
+			}
+		}
+	})
+}
+
+func TestStyledLogo(t *testing.T) {
+	got := zstyle.StyledLogo(zstyle.Title)
+	if got == "" {
+		t.Error("StyledLogo returned empty string")
+	}
+	// lipgloss may or may not emit ANSI in test environments,
+	// so we just verify the logo text survives styling
+	if !strings.Contains(got, "┌") {
+		t.Error("StyledLogo output missing logo content")
+	}
+}


### PR DESCRIPTION
Closes #38

Spec: .manager/specs/081-ascii-logo.md

Adds Logo constant and StyledLogo function to pkg/zstyle using box-drawing character ASCII art. Clean minimal 3-line wordmark that fits in 80 columns.