### PR TITLE
083: lowercase logo

### DIFF
--- a/pkg/zstyle/logo.go
+++ b/pkg/zstyle/logo.go
@@ -3,11 +3,11 @@ package zstyle
 import "github.com/charmbracelet/lipgloss"
 
 // Logo is the zarlcorp ASCII art wordmark for TUI splash screens.
-// uses box-drawing characters for a clean, minimal look.
+// lowercase letterforms with box-drawing characters.
 const Logo = "" +
-	"┌─┐┌─┐┬─┐┬  ┌─┐┌─┐┬─┐┌─┐\n" +
-	"┌─┘├─┤├┬┘│  │  │ │├┬┘├─┘\n" +
-	"└─┘┴ ┴┴└─┴─┘└─┘└─┘┴└─┴  "
+	"──┐ ┌─┐ ┌─┐ │   ┌── ┌─┐ ┌─┐ ┌─┐\n" +
+	"┌─┘ ├─┤ ├─┘ │   │   │ │ ├─┘ ├─┘\n" +
+	"└── ┴ ┴ ┴   └── └── └─┘ ┴   │  "
 
 // StyledLogo returns the logo rendered with the given lipgloss style.
 func StyledLogo(s lipgloss.Style) string {

--- a/pkg/zstyle/logo_test.go
+++ b/pkg/zstyle/logo_test.go
@@ -14,6 +14,13 @@ func TestLogo(t *testing.T) {
 		}
 	})
 
+	t.Run("three lines", func(t *testing.T) {
+		lines := strings.Split(zstyle.Logo, "\n")
+		if len(lines) != 3 {
+			t.Errorf("Logo has %d lines, want 3", len(lines))
+		}
+	})
+
 	t.Run("fits 80 columns", func(t *testing.T) {
 		for i, line := range strings.Split(zstyle.Logo, "\n") {
 			// count runes, not bytes — logo uses multibyte box-drawing chars


### PR DESCRIPTION
Closes #41

Spec: .manager/specs/083-lowercase-logo.md

Redesigns the zarlcorp ASCII art logo from uppercase to lowercase box-drawing letterforms. 3 lines tall, 31 runes wide, all letters clearly distinguishable with 1-space gaps.