### PR TITLE
091: zcrypto Erase hardening — compiler-resistant zeroing

### DIFF
--- a/pkg/zcrypto/erase.go
+++ b/pkg/zcrypto/erase.go
@@ -2,6 +2,12 @@ package zcrypto
 
 import "runtime"
 
+// eraser is an indirect function variable so the compiler cannot prove the
+// clear call is a dead store — it can't inline across the variable indirection.
+var eraser = func(b []byte) {
+	clear(b)
+}
+
 // Erase zeroes out a byte slice to prevent sensitive data from lingering in memory.
 //
 // This is best-effort: Go's garbage collector may copy memory during compaction,
@@ -9,10 +15,6 @@ import "runtime"
 // location is still worthwhile — it reduces the window of exposure and clears
 // the most obvious location an attacker would look.
 func Erase(b []byte) {
-	for i := range b {
-		b[i] = 0
-	}
-	// prevent the compiler from optimizing away the zeroing loop
-	// by ensuring the slice is considered reachable after the writes
+	eraser(b)
 	runtime.KeepAlive(&b)
 }


### PR DESCRIPTION
Closes #49

Spec: .manager/specs/091-zcrypto-erase-hardening.md

- replaced manual zeroing loop with `clear()` builtin (Go 1.21+)
- wrapped in package-level function variable to prevent dead-store elimination
- kept `runtime.KeepAlive` and best-effort doc comment
- all existing tests pass