### PR TITLE
089: MemoryCache TTL support via functional option

### DIFF
--- a/pkg/zcache/memory.go
+++ b/pkg/zcache/memory.go
@@ -3,6 +3,9 @@ package zcache
 import (
 	"context"
 	"sync"
+	"time"
+
+	"github.com/zarlcorp/core/pkg/zoptions"
 )
 
 var (
@@ -12,18 +15,52 @@ var (
 	_ Cache[string, any]      = (*MemoryCache[string, any])(nil)
 )
 
+// ttlEntry wraps a value with its insertion time for expiry tracking.
+type ttlEntry[V any] struct {
+	value     V
+	createdAt time.Time
+}
+
+// MemoryOption configures a MemoryCache.
+type MemoryOption[K comparable, V any] = zoptions.Option[MemoryCache[K, V]]
+
+// WithMemoryTTL sets the time-to-live for cache entries.
+// entries are lazily evicted on access when expired.
+// zero (default) means no expiry.
+func WithMemoryTTL[K comparable, V any](ttl time.Duration) MemoryOption[K, V] {
+	return func(mc *MemoryCache[K, V]) {
+		mc.ttl = ttl
+	}
+}
+
 // MemoryCache is a thread-safe generic cache implementation.
 // It provides concurrent access to a map with read-write locking for performance.
 type MemoryCache[K comparable, V any] struct {
 	mu   sync.RWMutex
 	data map[K]V
+
+	// ttl fields, only used when ttl > 0
+	ttl     time.Duration
+	ttlData map[K]ttlEntry[V]
+	now     func() time.Time // injectable for testing
 }
 
 // NewMemoryCache creates a new thread-safe memory cache with the specified key and value types.
-func NewMemoryCache[K comparable, V any]() *MemoryCache[K, V] {
-	return &MemoryCache[K, V]{
-		data: make(map[K]V),
+func NewMemoryCache[K comparable, V any](opts ...MemoryOption[K, V]) *MemoryCache[K, V] {
+	mc := &MemoryCache[K, V]{
+		now: time.Now,
 	}
+	for _, opt := range opts {
+		opt(mc)
+	}
+
+	if mc.ttl > 0 {
+		mc.ttlData = make(map[K]ttlEntry[V])
+	} else {
+		mc.data = make(map[K]V)
+	}
+
+	return mc
 }
 
 // Set stores a key-value pair in the cache.
@@ -37,18 +74,28 @@ func (c *MemoryCache[K, V]) Set(ctx context.Context, key K, value V) error {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.ttl > 0 {
+		c.ttlData[key] = ttlEntry[V]{value: value, createdAt: c.now()}
+		return nil
+	}
+
 	c.data[key] = value
 	return nil
 }
 
 // Get retrieves the value associated with the given key.
-// Returns ErrNotFound if the key does not exist.
+// Returns ErrNotFound if the key does not exist or has expired.
 func (c *MemoryCache[K, V]) Get(ctx context.Context, key K) (V, error) {
 	select {
 	case <-ctx.Done():
 		var zero V
 		return zero, ctx.Err()
 	default:
+	}
+
+	if c.ttl > 0 {
+		return c.getTTL(key)
 	}
 
 	c.mu.RLock()
@@ -60,6 +107,27 @@ func (c *MemoryCache[K, V]) Get(ctx context.Context, key K) (V, error) {
 		return zero, ErrNotFound
 	}
 	return value, nil
+}
+
+// getTTL handles Get with expiry checking.
+// uses a write lock because it may need to delete expired entries.
+func (c *MemoryCache[K, V]) getTTL(key K) (V, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, exists := c.ttlData[key]
+	if !exists {
+		var zero V
+		return zero, ErrNotFound
+	}
+
+	if c.now().Sub(entry.createdAt) >= c.ttl {
+		delete(c.ttlData, key)
+		var zero V
+		return zero, ErrNotFound
+	}
+
+	return entry.value, nil
 }
 
 // Delete removes a key-value pair from the cache.
@@ -74,6 +142,14 @@ func (c *MemoryCache[K, V]) Delete(ctx context.Context, key K) (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if c.ttl > 0 {
+		_, exists := c.ttlData[key]
+		if exists {
+			delete(c.ttlData, key)
+		}
+		return exists, nil
+	}
+
 	_, exists := c.data[key]
 	if exists {
 		delete(c.data, key)
@@ -82,6 +158,7 @@ func (c *MemoryCache[K, V]) Delete(ctx context.Context, key K) (bool, error) {
 }
 
 // Len returns the number of entries in the cache.
+// When TTL is set, expired entries are excluded from the count.
 func (c *MemoryCache[K, V]) Len(ctx context.Context) (int, error) {
 	select {
 	case <-ctx.Done():
@@ -89,9 +166,27 @@ func (c *MemoryCache[K, V]) Len(ctx context.Context) (int, error) {
 	default:
 	}
 
+	if c.ttl > 0 {
+		return c.lenTTL(), nil
+	}
+
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return len(c.data), nil
+}
+
+// lenTTL counts non-expired entries and cleans up expired ones.
+func (c *MemoryCache[K, V]) lenTTL() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	for k, entry := range c.ttlData {
+		if now.Sub(entry.createdAt) >= c.ttl {
+			delete(c.ttlData, k)
+		}
+	}
+	return len(c.ttlData)
 }
 
 // Clear removes all entries from the cache.
@@ -104,6 +199,12 @@ func (c *MemoryCache[K, V]) Clear(ctx context.Context) error {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.ttl > 0 {
+		c.ttlData = make(map[K]ttlEntry[V])
+		return nil
+	}
+
 	c.data = make(map[K]V)
 	return nil
 }

--- a/pkg/zcache/memory_test.go
+++ b/pkg/zcache/memory_test.go
@@ -2,6 +2,7 @@ package zcache_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/zarlcorp/core/pkg/zcache"
 )
@@ -70,4 +71,113 @@ func TestMemoryCache_Constructor(t *testing.T) {
 			tt.check(t, c)
 		})
 	}
+}
+
+func TestMemoryCache_TTL(t *testing.T) {
+	t.Run("entry expires after TTL", func(t *testing.T) {
+		c := zcache.NewMemoryCache[string, int](
+			zcache.WithMemoryTTL[string, int](50 * time.Millisecond),
+		)
+		ctx := t.Context()
+
+		c.Set(ctx, "key", 42)
+
+		// should be accessible immediately
+		got, err := c.Get(ctx, "key")
+		if err != nil {
+			t.Fatalf("Get() before expiry: %v", err)
+		}
+		if got != 42 {
+			t.Errorf("Get() = %v, want 42", got)
+		}
+
+		// wait for TTL to expire
+		time.Sleep(60 * time.Millisecond)
+
+		_, err = c.Get(ctx, "key")
+		if err != zcache.ErrNotFound {
+			t.Errorf("Get() after expiry: got %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("entry accessible before TTL", func(t *testing.T) {
+		c := zcache.NewMemoryCache[string, int](
+			zcache.WithMemoryTTL[string, int](1 * time.Second),
+		)
+		ctx := t.Context()
+
+		c.Set(ctx, "key", 99)
+
+		got, err := c.Get(ctx, "key")
+		if err != nil {
+			t.Fatalf("Get() before expiry: %v", err)
+		}
+		if got != 99 {
+			t.Errorf("Get() = %v, want 99", got)
+		}
+	})
+
+	t.Run("zero TTL means no expiry", func(t *testing.T) {
+		c := zcache.NewMemoryCache[string, int]()
+		ctx := t.Context()
+
+		c.Set(ctx, "key", 1)
+
+		got, err := c.Get(ctx, "key")
+		if err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+		if got != 1 {
+			t.Errorf("Get() = %v, want 1", got)
+		}
+	})
+
+	t.Run("Len excludes expired entries", func(t *testing.T) {
+		c := zcache.NewMemoryCache[string, int](
+			zcache.WithMemoryTTL[string, int](50 * time.Millisecond),
+		)
+		ctx := t.Context()
+
+		c.Set(ctx, "a", 1)
+		c.Set(ctx, "b", 2)
+
+		got, _ := c.Len(ctx)
+		if got != 2 {
+			t.Errorf("Len() before expiry = %v, want 2", got)
+		}
+
+		time.Sleep(60 * time.Millisecond)
+
+		// add one fresh entry after the old ones expire
+		c.Set(ctx, "c", 3)
+
+		got, _ = c.Len(ctx)
+		if got != 1 {
+			t.Errorf("Len() after partial expiry = %v, want 1", got)
+		}
+	})
+
+	t.Run("Set refreshes TTL on existing key", func(t *testing.T) {
+		c := zcache.NewMemoryCache[string, int](
+			zcache.WithMemoryTTL[string, int](80 * time.Millisecond),
+		)
+		ctx := t.Context()
+
+		c.Set(ctx, "key", 1)
+
+		// wait 50ms, then re-set to refresh
+		time.Sleep(50 * time.Millisecond)
+		c.Set(ctx, "key", 2)
+
+		// wait another 50ms -- would have expired under the original insertion time
+		time.Sleep(50 * time.Millisecond)
+
+		got, err := c.Get(ctx, "key")
+		if err != nil {
+			t.Fatalf("Get() after refresh: %v", err)
+		}
+		if got != 2 {
+			t.Errorf("Get() = %v, want 2", got)
+		}
+	})
 }


### PR DESCRIPTION
Closes #47

Spec: .manager/specs/089-memorycache-ttl.md

- added WithMemoryTTL functional option following zoptions pattern
- lazy expiry on Get/Len — no background goroutine
- zero TTL (default) preserves existing behavior with no overhead
- Set refreshes TTL on existing keys
- injectable time source for deterministic testing
- all existing and new tests pass