### PR TITLE
090: zapp Track-after-Close error + remove dead name field

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import (
 )
 
 func main() {
-    app := zapp.New(zapp.WithName("example"))
+    app := zapp.New()
     ctx, cancel := zapp.SignalContext(context.Background())
     defer cancel()
 

--- a/pkg/zapp/options.go
+++ b/pkg/zapp/options.go
@@ -1,8 +1,1 @@
 package zapp
-
-// WithName overrides the default application name.
-func WithName(name string) Option {
-	return func(a *App) {
-		a.name = name
-	}
-}


### PR DESCRIPTION
Closes #48

Spec: .manager/specs/090-zapp-track-and-name.md

- Track now returns error; returns ErrClosed after Close has been called
- removed unused name field and WithName option
- removed unused os/filepath imports
- updated package doc example
- all tests pass