### PR TITLE
085: zsync API fixes — ZMap Get pattern + queue memory leak

### DIFF
--- a/pkg/zfilesystem/memfs.go
+++ b/pkg/zfilesystem/memfs.go
@@ -52,8 +52,8 @@ func (mfs *MemFS) ReadFile(filename string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	file, err := mfs.files.Get(p)
-	if err != nil {
+	file, ok := mfs.files.Get(p)
+	if !ok {
 		return nil, os.ErrNotExist
 	}
 
@@ -112,8 +112,8 @@ func (mfs *MemFS) OpenFile(name string, flag int, perm fs.FileMode) (File, error
 	}
 
 	// For read operations, check if file exists
-	file, err := mfs.files.Get(p)
-	if err != nil {
+	file, ok := mfs.files.Get(p)
+	if !ok {
 		return nil, os.ErrNotExist
 	}
 
@@ -135,8 +135,8 @@ func (mfs *MemFS) WalkDir(root string, fn fs.WalkDirFunc) error {
 	keys := mfs.files.Keys()
 
 	for _, filename := range keys {
-		file, err := mfs.files.Get(filename)
-		if err != nil {
+		file, ok := mfs.files.Get(filename)
+		if !ok {
 			continue
 		}
 
@@ -237,8 +237,8 @@ func (fh *memFileHandle) Stat() (fs.FileInfo, error) {
 		return nil, fs.ErrClosed
 	}
 
-	file, err := fh.mfs.files.Get(fh.filename)
-	if err != nil {
+	file, ok := fh.mfs.files.Get(fh.filename)
+	if !ok {
 		// If file doesn't exist yet (new file), return basic info
 		return &memFileInfo{
 			name:    filepath.Base(fh.filename),

--- a/pkg/zsync/map.go
+++ b/pkg/zsync/map.go
@@ -27,17 +27,13 @@ func (m *ZMap[K, V]) Set(key K, value V) {
 }
 
 // Get retrieves the value associated with the given key.
-// Returns ErrNotFound if the key does not exist.
-func (m *ZMap[K, V]) Get(key K) (V, error) {
+// Returns the value and true if found, or the zero value and false if not.
+func (m *ZMap[K, V]) Get(key K) (V, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	value, exists := m.data[key]
-	if !exists {
-		var zero V
-		return zero, ErrNotFound
-	}
-	return value, nil
+	value, ok := m.data[key]
+	return value, ok
 }
 
 // Delete removes a key-value pair from the map.

--- a/pkg/zsync/map_test.go
+++ b/pkg/zsync/map_test.go
@@ -1,7 +1,6 @@
 package zsync_test
 
 import (
-	"errors"
 	"sync"
 	"testing"
 
@@ -36,9 +35,9 @@ func TestZMap_Set(t *testing.T) {
 			m := zsync.NewZMap[string, int]()
 			m.Set(tt.key, tt.value)
 
-			got, err := m.Get(tt.key)
-			if err != nil {
-				t.Errorf("Get() error = %v, want nil", err)
+			got, ok := m.Get(tt.key)
+			if !ok {
+				t.Errorf("Get() ok = false, want true")
 				return
 			}
 			if got != tt.value {
@@ -50,31 +49,32 @@ func TestZMap_Set(t *testing.T) {
 
 func TestZMap_Get(t *testing.T) {
 	tests := []struct {
-		name  string
-		setup map[string]int
-		key   string
-		want  int
-		error error
+		name   string
+		setup  map[string]int
+		key    string
+		want   int
+		wantOK bool
 	}{
 		{
-			name:  "get existing key",
-			setup: map[string]int{"test": 42},
-			key:   "test",
-			want:  42,
+			name:   "get existing key",
+			setup:  map[string]int{"test": 42},
+			key:    "test",
+			want:   42,
+			wantOK: true,
 		},
 		{
-			name:  "get non-existent key",
-			setup: map[string]int{},
-			key:   "missing",
-			want:  0,
-			error: zsync.ErrNotFound,
+			name:   "get non-existent key",
+			setup:  map[string]int{},
+			key:    "missing",
+			want:   0,
+			wantOK: false,
 		},
 		{
-			name:  "get from empty map",
-			setup: nil,
-			key:   "any",
-			want:  0,
-			error: zsync.ErrNotFound,
+			name:   "get from empty map",
+			setup:  nil,
+			key:    "any",
+			want:   0,
+			wantOK: false,
 		},
 	}
 
@@ -87,9 +87,9 @@ func TestZMap_Get(t *testing.T) {
 				m.Set(k, v)
 			}
 
-			got, err := m.Get(tt.key)
-			if !errors.Is(err, tt.error) {
-				t.Errorf("Get() error = %v, want %v", err, tt.error)
+			got, ok := m.Get(tt.key)
+			if ok != tt.wantOK {
+				t.Errorf("Get() ok = %v, want %v", ok, tt.wantOK)
 				return
 			}
 			if got != tt.want {
@@ -256,9 +256,9 @@ func TestZMap_Clear(t *testing.T) {
 		t.Errorf("Len() after clear = %v, want 0", m.Len())
 	}
 
-	_, err := m.Get("a")
-	if !errors.Is(err, zsync.ErrNotFound) {
-		t.Errorf("Get() after clear error = %v, want %v", err, zsync.ErrNotFound)
+	_, ok := m.Get("a")
+	if ok {
+		t.Errorf("Get() after clear ok = true, want false")
 	}
 }
 

--- a/pkg/zsync/queue.go
+++ b/pkg/zsync/queue.go
@@ -58,6 +58,8 @@ func (q *ZQueue[T]) Pop() (T, error) {
 	}
 
 	item := q.items[0]
+	var zero T
+	q.items[0] = zero
 	q.items = q.items[1:]
 	return item, nil
 }
@@ -105,6 +107,8 @@ func (q *ZQueue[T]) PopContext(ctx context.Context) (T, error) {
 	}
 
 	item := q.items[0]
+	var zero T
+	q.items[0] = zero
 	q.items = q.items[1:]
 	return item, nil
 }
@@ -121,6 +125,8 @@ func (q *ZQueue[T]) TryPop() (T, error) {
 	}
 
 	item := q.items[0]
+	var zero T
+	q.items[0] = zero
 	q.items = q.items[1:]
 	return item, nil
 }

--- a/pkg/zsync/queue_internal_test.go
+++ b/pkg/zsync/queue_internal_test.go
@@ -1,0 +1,70 @@
+package zsync
+
+import "testing"
+
+// verifies that popped elements are zeroed in the backing array so the queue
+// doesn't retain references to values that have already been consumed.
+func TestZQueue_popZeroesBackingArray(t *testing.T) {
+	q := NewZQueue[*string]()
+
+	s := "hello"
+	q.Push(&s)
+
+	// grab reference to backing array before pop
+	backing := q.items[:1]
+
+	got, err := q.Pop()
+	if err != nil {
+		t.Fatalf("Pop() error = %v", err)
+	}
+	if *got != "hello" {
+		t.Fatalf("Pop() = %v, want hello", *got)
+	}
+
+	// the element at index 0 of the original backing array should be nil
+	if backing[0] != nil {
+		t.Errorf("backing array still holds reference after Pop")
+	}
+}
+
+func TestZQueue_tryPopZeroesBackingArray(t *testing.T) {
+	q := NewZQueue[*string]()
+
+	s := "world"
+	q.Push(&s)
+
+	backing := q.items[:1]
+
+	got, err := q.TryPop()
+	if err != nil {
+		t.Fatalf("TryPop() error = %v", err)
+	}
+	if *got != "world" {
+		t.Fatalf("TryPop() = %v, want world", *got)
+	}
+
+	if backing[0] != nil {
+		t.Errorf("backing array still holds reference after TryPop")
+	}
+}
+
+func TestZQueue_popContextZeroesBackingArray(t *testing.T) {
+	q := NewZQueue[*string]()
+
+	s := "ctx"
+	q.Push(&s)
+
+	backing := q.items[:1]
+
+	got, err := q.PopContext(t.Context())
+	if err != nil {
+		t.Fatalf("PopContext() error = %v", err)
+	}
+	if *got != "ctx" {
+		t.Fatalf("PopContext() = %v, want ctx", *got)
+	}
+
+	if backing[0] != nil {
+		t.Errorf("backing array still holds reference after PopContext")
+	}
+}

--- a/pkg/zsync/set.go
+++ b/pkg/zsync/set.go
@@ -27,8 +27,8 @@ func (s *ZSet[T]) Add(value T) {
 // Contains checks if a value exists in the set.
 // Returns true if the value is present, false otherwise.
 func (s *ZSet[T]) Contains(value T) bool {
-	_, err := s.m.Get(value)
-	return err == nil
+	_, ok := s.m.Get(value)
+	return ok
 }
 
 // Remove deletes a value from the set.

--- a/pkg/zsync/set_bench_test.go
+++ b/pkg/zsync/set_bench_test.go
@@ -150,8 +150,8 @@ func (ss *stdSet) Add(item string) {
 }
 
 func (ss *stdSet) Contains(item string) bool {
-	_, err := ss.m.Get(item)
-	return err == nil
+	_, ok := ss.m.Get(item)
+	return ok
 }
 
 func BenchmarkStdSet_Add(b *testing.B) {

--- a/pkg/zsync/zsync.go
+++ b/pkg/zsync/zsync.go
@@ -18,11 +18,10 @@
 // # Error Handling
 //
 // All operations follow consistent error handling patterns:
-//   - ErrNotFound: Returned when attempting to access non-existent keys/values
 //   - ErrQueueClosed: Returned when attempting to operate on a closed queue
 //   - ErrQueueEmpty: Returned when attempting to pop from an empty queue
 //   - ErrCanceled: Returned when operations are canceled via context
-//   - Boolean returns: Indicate success/failure for operations like Delete/Remove
+//   - Boolean returns: Indicate success/failure for operations like Get, Delete, Remove
 //   - No panics: All error conditions are handled gracefully
 //
 // # Performance Characteristics
@@ -39,9 +38,9 @@
 //	m := zsync.NewZMap[string, int]()
 //	m.Set("key", 42)
 //
-//	value, err := m.Get("key")
-//	if err != nil {
-//	    // handle ErrNotFound
+//	value, ok := m.Get("key")
+//	if !ok {
+//	    // key not found
 //	}
 //
 //	existed := m.Delete("key")
@@ -81,7 +80,6 @@ import "errors"
 
 // Package-level errors used across multiple data structures
 var (
-	ErrNotFound    = errors.New("key not found")
 	ErrQueueClosed = errors.New("queue closed")
 	ErrQueueEmpty  = errors.New("queue empty")
 	ErrCanceled    = errors.New("operation canceled")


### PR DESCRIPTION
Closes #43

Spec: .manager/specs/085-zsync-api-fixes.md

- changed ZMap.Get from (V, error) to idiomatic (V, bool)
- removed ErrNotFound from zsync (only queue errors remain)
- updated ZSet.Contains, MemFS, and all tests for new signature
- zero queue elements before re-slicing in Pop/TryPop/PopContext
- added internal tests verifying backing array is zeroed
- all tests pass across zsync, zfilesystem, and zcache