### PR TITLE
085: ribbon logo

### DIFF
--- a/pkg/zstyle/logo.go
+++ b/pkg/zstyle/logo.go
@@ -3,11 +3,13 @@ package zstyle
 import "github.com/charmbracelet/lipgloss"
 
 // Logo is the zarlcorp ASCII art wordmark for TUI splash screens.
-// lowercase letterforms with box-drawing characters.
+// ribbon/origami letterforms with diagonal box-drawing characters.
 const Logo = "" +
-	"──┐ ┌─┐ ┌─┐ │   ┌── ┌─┐ ┌─┐ ┌─┐\n" +
-	"┌─┘ ├─┤ ├─┘ │   │   │ │ ├─┘ ├─┘\n" +
-	"└── ┴ ┴ ┴   └── └── └─┘ ┴   │  "
+	"   ________  ________  ________  ______    ________  ________  ________  ________ \n" +
+	"  ╱        ╲╱        ╲╱        ╲╱      ╲  ╱        ╲╱        ╲╱        ╲╱        ╲\n" +
+	" ╱-        ╱    /    ╱     /   ╱       ╱ ╱         ╱    /    ╱    /    ╱    /    ╱\n" +
+	"╱        _╱         ╱        _╱       ╱_╱       --╱         ╱        _╱       __╱ \n" +
+	"╲________╱╲___╱____╱╲____╱___╱╲________╱╲________╱╲________╱╲____╱___╱╲______╱    "
 
 // StyledLogo returns the logo rendered with the given lipgloss style.
 func StyledLogo(s lipgloss.Style) string {

--- a/pkg/zstyle/logo_test.go
+++ b/pkg/zstyle/logo_test.go
@@ -14,22 +14,22 @@ func TestLogo(t *testing.T) {
 		}
 	})
 
-	t.Run("three lines", func(t *testing.T) {
+	t.Run("five lines", func(t *testing.T) {
 		lines := strings.Split(zstyle.Logo, "\n")
-		if len(lines) != 3 {
-			t.Errorf("Logo has %d lines, want 3", len(lines))
+		if len(lines) != 5 {
+			t.Errorf("Logo has %d lines, want 5", len(lines))
 		}
 	})
 
-	t.Run("fits 80 columns", func(t *testing.T) {
+	t.Run("fits 90 columns", func(t *testing.T) {
 		for i, line := range strings.Split(zstyle.Logo, "\n") {
 			// count runes, not bytes — logo uses multibyte box-drawing chars
 			n := 0
 			for range line {
 				n++
 			}
-			if n > 80 {
-				t.Errorf("line %d is %d runes wide, want <= 80", i, n)
+			if n > 90 {
+				t.Errorf("line %d is %d runes wide, want <= 90", i, n)
 			}
 		}
 	})
@@ -42,7 +42,7 @@ func TestStyledLogo(t *testing.T) {
 	}
 	// lipgloss may or may not emit ANSI in test environments,
 	// so we just verify the logo text survives styling
-	if !strings.Contains(got, "┌") {
+	if !strings.Contains(got, "╱") {
 		t.Error("StyledLogo output missing logo content")
 	}
 }


### PR DESCRIPTION
Replaces the 3-line box-drawing logo with a 5-line ribbon/origami style logo using diagonal ╱╲ characters. Updates tests for new line count and width.