### PR TITLE
093: zcache Redis tests with miniredis

### DIFF
--- a/pkg/zcache/cache_test.go
+++ b/pkg/zcache/cache_test.go
@@ -22,11 +22,11 @@ func TestCache_Contract(t *testing.T) {
 		{
 			name: "RedisCache",
 			newCache: func(t *testing.T) (zcache.Cache[string, int], func()) {
-				if testing.Short() {
-					t.Skip("skipping Redis tests in short mode")
-				}
-
-				c := zcache.NewRedisCache[string, int](zcache.WithPrefix[string, int]("pre"))
+				client := newTestRedisClient(t)
+				c := zcache.NewRedisCache[string, int](
+					zcache.WithPrefix[string, int]("pre"),
+					zcache.WithClient[string, int](client),
+				)
 
 				cleanup := func() {
 					c.Clear(t.Context())

--- a/pkg/zcache/go.mod
+++ b/pkg/zcache/go.mod
@@ -3,6 +3,7 @@ module github.com/zarlcorp/core/pkg/zcache
 go 1.26.0
 
 require (
+	github.com/alicebob/miniredis/v2 v2.36.1
 	github.com/redis/go-redis/v9 v9.12.1
 	github.com/zarlcorp/core/pkg/zfilesystem v0.1.0
 	github.com/zarlcorp/core/pkg/zoptions v0.1.0
@@ -11,5 +12,6 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/zarlcorp/core/pkg/zsync v0.1.0 // indirect
 )

--- a/pkg/zcache/go.sum
+++ b/pkg/zcache/go.sum
@@ -1,3 +1,5 @@
+github.com/alicebob/miniredis/v2 v2.36.1 h1:Dvc5oAnNOr7BIfPn7tF269U8DvRW1dBG2D5n0WrfYMI=
+github.com/alicebob/miniredis/v2 v2.36.1/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -8,6 +10,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/redis/go-redis/v9 v9.12.1 h1:k5iquqv27aBtnTm2tIkROUDp8JBXhXZIVu1InSgvovg=
 github.com/redis/go-redis/v9 v9.12.1/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zarlcorp/core/pkg/zfilesystem v0.1.0 h1:8jJ1nY3OFwNmqOIchPq1+WiRuYDUlHqG1WKRcGiWB0c=
 github.com/zarlcorp/core/pkg/zfilesystem v0.1.0/go.mod h1:6XxQ4wSlFNHzZSfM+YxKysrlTAUHcdQeIfCs9ebc2Zc=
 github.com/zarlcorp/core/pkg/zoptions v0.1.0 h1:/WgBilZ7tXGfqcq76nd8BOQv/JRaCsj7TLOXE5JNh7s=


### PR DESCRIPTION
Closes #60

Spec: .manager/specs/093-zcache-miniredis.md

- added alicebob/miniredis/v2 as test dependency
- all Redis contract tests now run without a real Redis server
- removed all testing.Short() skips from Redis tests
- prefix isolation test verified against shared miniredis instance
- all tests pass without -short