### PR TITLE
094: fix zstyle lint findings

### DIFF
--- a/pkg/zstyle/colors.go
+++ b/pkg/zstyle/colors.go
@@ -62,9 +62,9 @@ var (
 
 // per-tool accent colors
 var (
-	ZburnAccent   = Peach    // warm — fire, burning
-	ZvaultAccent  = Mauve    // regal — vaults, secrets
-	ZshieldAccent = Teal     // protective — shields, safety
+	ZburnAccent   = Peach // warm — fire, burning
+	ZvaultAccent  = Mauve // regal — vaults, secrets
+	ZshieldAccent = Teal  // protective — shields, safety
 )
 
 // CSSVariables exports the full catppuccin mocha palette as CSS custom properties.

--- a/pkg/zstyle/logo.go
+++ b/pkg/zstyle/logo.go
@@ -12,6 +12,6 @@ const Logo = "" +
 	"╲________╱╲___╱____╱╲____╱___╱╲________╱╲________╱╲________╱╲____╱___╱╲______╱    "
 
 // StyledLogo returns the logo rendered with the given lipgloss style.
-func StyledLogo(s lipgloss.Style) string {
+func StyledLogo(s *lipgloss.Style) string {
 	return s.Render(Logo)
 }

--- a/pkg/zstyle/logo_test.go
+++ b/pkg/zstyle/logo_test.go
@@ -36,7 +36,8 @@ func TestLogo(t *testing.T) {
 }
 
 func TestStyledLogo(t *testing.T) {
-	got := zstyle.StyledLogo(zstyle.Title)
+	s := zstyle.Title
+	got := zstyle.StyledLogo(&s)
 	if got == "" {
 		t.Error("StyledLogo returned empty string")
 	}

--- a/pkg/zstyle/zstyle_test.go
+++ b/pkg/zstyle/zstyle_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestBaseColors(t *testing.T) {
 	colors := []struct {
-		name string
+		name  string
 		color lipgloss.Color
-		hex  string
+		hex   string
 	}{
 		{"Base", zstyle.Base, "#1e1e2e"},
 		{"Mantle", zstyle.Mantle, "#181825"},
@@ -149,7 +149,7 @@ func TestCSSVariables(t *testing.T) {
 	}
 
 	for _, want := range required {
-		if !strings.Contains(zstyle.CSSVariables, want) {
+		if !strings.Contains(zstyle.CSSVariables, want) { //nolint:gocritic // args are correct: haystack, needle
 			t.Errorf("CSSVariables missing %q", want)
 		}
 	}


### PR DESCRIPTION
- StyledLogo takes *lipgloss.Style to avoid 552-byte copy
- gofumpt formatting in colors.go and zstyle_test.go
- suppress false-positive gocritic argOrder on CSSVariables check
- 0 lint issues, all tests pass