### PR TITLE
095: remove go get install commands from landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -38,12 +38,6 @@
           </div>
         </div>
       </section>
-      <section class="install">
-        <div class="install-cmd"><span class="prompt">$ </span>go get github.com/zarlcorp/core/pkg/zapp</div>
-        <div class="install-cmd"><span class="prompt">$ </span>go get github.com/zarlcorp/core/pkg/zstyle</div>
-        <div class="install-cmd"><span class="prompt">$ </span>go get github.com/zarlcorp/core/pkg/zcache</div>
-        <div class="install-cmd"><span class="prompt">$ </span>go get github.com/zarlcorp/core/pkg/zsync</div>
-      </section>
       <div class="landing-links">
         <a href="docs.html">docs</a>
         <span class="sep">/</span>

--- a/docs/style.css
+++ b/docs/style.css
@@ -9,11 +9,6 @@
   padding: 0.75rem 0;
 }
 
-/* install commands spacing */
-.install .install-cmd + .install-cmd {
-  margin-top: 0.5rem;
-}
-
 /* links row */
 .landing-links {
   text-align: center;


### PR DESCRIPTION
removes the go get install section from docs/index.html and the related CSS rule from docs/style.css