### PR TITLE
095: zstore — encrypted collection storage

### DIFF
--- a/go.work
+++ b/go.work
@@ -6,6 +6,7 @@ use (
 	./pkg/zcrypto
 	./pkg/zfilesystem
 	./pkg/zoptions
+	./pkg/zstore
 	./pkg/zstyle
 	./pkg/zsync
 )

--- a/pkg/zstore/collection.go
+++ b/pkg/zstore/collection.go
@@ -1,0 +1,159 @@
+package zstore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/zarlcorp/core/pkg/zcrypto"
+)
+
+// Collection is a typed, encrypted key-value collection within a Store.
+// Each collection has its own HKDF-derived sub-key so compromising one
+// collection does not expose another.
+type Collection[V any] struct {
+	store *Store
+	name  string
+	key   []byte
+}
+
+// NewCollection returns a typed collection backed by the given store.
+// It creates a subdirectory for the collection and derives a sub-key
+// via HKDF using the collection name as the info parameter.
+func NewCollection[V any](store *Store, name string) (*Collection[V], error) {
+	if err := store.fs.MkdirAll(name, 0o700); err != nil {
+		return nil, fmt.Errorf("create collection directory: %w", err)
+	}
+
+	key, err := zcrypto.ExpandKey(store.masterKey, store.salt, []byte(name))
+	if err != nil {
+		return nil, fmt.Errorf("derive collection key: %w", err)
+	}
+
+	store.subKeys = append(store.subKeys, key)
+
+	return &Collection[V]{store: store, name: name, key: key}, nil
+}
+
+// Put encrypts and stores a value under the given id.
+func (c *Collection[V]) Put(id string, value V) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal value: %w", err)
+	}
+
+	ct, err := zcrypto.Encrypt(c.key, data)
+	if err != nil {
+		return fmt.Errorf("encrypt value: %w", err)
+	}
+
+	path := filepath.Join(c.name, id+".enc")
+	if err := c.store.fs.WriteFile(path, ct, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// Get reads, decrypts, and unmarshals a value by id.
+// Returns ErrNotFound if the id does not exist.
+func (c *Collection[V]) Get(id string) (V, error) {
+	var zero V
+
+	path := filepath.Join(c.name, id+".enc")
+	ct, err := c.store.fs.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return zero, ErrNotFound
+		}
+		return zero, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	plain, err := zcrypto.Decrypt(c.key, ct)
+	if err != nil {
+		return zero, fmt.Errorf("decrypt %s: %w", path, err)
+	}
+
+	var v V
+	if err := json.Unmarshal(plain, &v); err != nil {
+		return zero, fmt.Errorf("unmarshal %s: %w", path, err)
+	}
+
+	return v, nil
+}
+
+// Delete removes a value by id. Returns ErrNotFound if the id does not exist.
+func (c *Collection[V]) Delete(id string) error {
+	path := filepath.Join(c.name, id+".enc")
+	if err := c.store.fs.Remove(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("remove %s: %w", path, err)
+	}
+	return nil
+}
+
+// List decrypts and returns all values in the collection.
+// The order is not guaranteed.
+func (c *Collection[V]) List() ([]V, error) {
+	var values []V
+
+	err := c.store.fs.WalkDir(c.name, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".enc") {
+			return nil
+		}
+
+		ct, err := c.store.fs.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+
+		plain, err := zcrypto.Decrypt(c.key, ct)
+		if err != nil {
+			return fmt.Errorf("decrypt %s: %w", path, err)
+		}
+
+		var v V
+		if err := json.Unmarshal(plain, &v); err != nil {
+			return fmt.Errorf("unmarshal %s: %w", path, err)
+		}
+
+		values = append(values, v)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return values, nil
+}
+
+// Len returns the number of encrypted entries without decrypting them.
+func (c *Collection[V]) Len() (int, error) {
+	count := 0
+
+	err := c.store.fs.WalkDir(c.name, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".enc") {
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}

--- a/pkg/zstore/go.mod
+++ b/pkg/zstore/go.mod
@@ -1,0 +1,14 @@
+module github.com/zarlcorp/core/pkg/zstore
+
+go 1.26.0
+
+require (
+	github.com/zarlcorp/core/pkg/zcrypto v0.1.0
+	github.com/zarlcorp/core/pkg/zfilesystem v0.1.0
+)
+
+require (
+	github.com/zarlcorp/core/pkg/zsync v0.1.0 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
+)

--- a/pkg/zstore/go.sum
+++ b/pkg/zstore/go.sum
@@ -1,0 +1,10 @@
+github.com/zarlcorp/core/pkg/zcrypto v0.1.0 h1:5cE1BN6ryYm3moihVYCjenoZFyd2u/N/v4LpJ3Ipyb0=
+github.com/zarlcorp/core/pkg/zcrypto v0.1.0/go.mod h1:jRnfySJa1krOIDJV6puuvuEODV+wVwJuF0JLAIcSLlc=
+github.com/zarlcorp/core/pkg/zfilesystem v0.1.0 h1:8jJ1nY3OFwNmqOIchPq1+WiRuYDUlHqG1WKRcGiWB0c=
+github.com/zarlcorp/core/pkg/zfilesystem v0.1.0/go.mod h1:6XxQ4wSlFNHzZSfM+YxKysrlTAUHcdQeIfCs9ebc2Zc=
+github.com/zarlcorp/core/pkg/zsync v0.1.0 h1:XR/HFKu+mK/4XkEAkTrcaiCOahyWxqBS5l6XhwgZJwI=
+github.com/zarlcorp/core/pkg/zsync v0.1.0/go.mod h1:uPnywnOHOaotnMrrSzPBeziPPZgtS0aEMZL1XcnrcO4=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/pkg/zstore/options.go
+++ b/pkg/zstore/options.go
@@ -1,0 +1,15 @@
+package zstore
+
+// options holds configuration for the store.
+type options struct{}
+
+// Option configures a Store.
+type Option func(*options)
+
+func applyOptions(opts []Option) options {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}

--- a/pkg/zstore/zstore.go
+++ b/pkg/zstore/zstore.go
@@ -1,0 +1,122 @@
+// Package zstore provides generic encrypted key-value storage built on
+// zfilesystem and zcrypto. It uses HKDF to derive per-collection sub-keys
+// from a single master key, so compromising one collection's key does not
+// expose others.
+//
+// # Usage
+//
+//	fs := zfilesystem.NewMemFS()
+//	s, err := zstore.Open(fs, []byte("password"))
+//	if err != nil {
+//	    // handle error
+//	}
+//	defer s.Close()
+//
+//	col := zstore.Collection[MyType](s, "things")
+//	err = col.Put("id1", MyType{Name: "hello"})
+package zstore
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/zarlcorp/core/pkg/zcrypto"
+	"github.com/zarlcorp/core/pkg/zfilesystem"
+)
+
+const (
+	saltFile   = "salt"
+	verifyFile = "verify"
+	verifyText = "zstore-verify-ok"
+)
+
+// ErrNotFound is returned when a key does not exist.
+var ErrNotFound = errors.New("not found")
+
+// ErrWrongPassword is returned when the password does not match the store.
+var ErrWrongPassword = errors.New("wrong password")
+
+// Store is an encrypted key-value store. It holds a master key derived from
+// the user's password and supports multiple typed collections, each with
+// its own HKDF-derived sub-key.
+type Store struct {
+	fs        zfilesystem.ReadWriteFileFS
+	masterKey []byte
+	salt      []byte
+	subKeys   [][]byte
+}
+
+// Open creates or opens a store. On first run it generates a salt, derives a
+// master key, creates a verification token, and stores both via the filesystem.
+// On subsequent runs it reads the salt, derives the key, and verifies the
+// password by decrypting the verification token.
+func Open(fs zfilesystem.ReadWriteFileFS, password []byte, opts ...Option) (*Store, error) {
+	_ = applyOptions(opts)
+
+	salt, err := fs.ReadFile(saltFile)
+	if err != nil {
+		return initStore(fs, password)
+	}
+
+	return openStore(fs, password, salt)
+}
+
+// initStore handles first-run initialization: generate salt, derive key,
+// encrypt a verification token, persist both.
+func initStore(fs zfilesystem.ReadWriteFileFS, password []byte) (*Store, error) {
+	salt, err := zcrypto.RandBytes(zcrypto.SaltSize)
+	if err != nil {
+		return nil, fmt.Errorf("generate salt: %w", err)
+	}
+
+	if err := fs.WriteFile(saltFile, salt, 0o600); err != nil {
+		return nil, fmt.Errorf("write salt: %w", err)
+	}
+
+	key, _, err := zcrypto.DeriveKey(password, salt)
+	if err != nil {
+		return nil, fmt.Errorf("derive key: %w", err)
+	}
+
+	token, err := zcrypto.Encrypt(key, []byte(verifyText))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt verification token: %w", err)
+	}
+
+	if err := fs.WriteFile(verifyFile, token, 0o600); err != nil {
+		return nil, fmt.Errorf("write verification token: %w", err)
+	}
+
+	return &Store{fs: fs, masterKey: key, salt: salt}, nil
+}
+
+// openStore handles subsequent opens: derive key from existing salt, verify
+// password against the stored verification token.
+func openStore(fs zfilesystem.ReadWriteFileFS, password, salt []byte) (*Store, error) {
+	key, _, err := zcrypto.DeriveKey(password, salt)
+	if err != nil {
+		return nil, fmt.Errorf("derive key: %w", err)
+	}
+
+	token, err := fs.ReadFile(verifyFile)
+	if err != nil {
+		return nil, fmt.Errorf("read verification token: %w", err)
+	}
+
+	plain, err := zcrypto.Decrypt(key, token)
+	if err != nil || string(plain) != verifyText {
+		zcrypto.Erase(key)
+		return nil, ErrWrongPassword
+	}
+
+	return &Store{fs: fs, masterKey: key, salt: salt}, nil
+}
+
+// Close erases the master key and all sub-keys from memory.
+func (s *Store) Close() error {
+	zcrypto.Erase(s.masterKey)
+	for _, k := range s.subKeys {
+		zcrypto.Erase(k)
+	}
+	return nil
+}

--- a/pkg/zstore/zstore_export_test.go
+++ b/pkg/zstore/zstore_export_test.go
@@ -1,0 +1,7 @@
+package zstore
+
+// MasterKeyForTest returns the master key slice for test assertions.
+func (s *Store) MasterKeyForTest() []byte { return s.masterKey }
+
+// SubKeysForTest returns the sub-key slices for test assertions.
+func (s *Store) SubKeysForTest() [][]byte { return s.subKeys }

--- a/pkg/zstore/zstore_test.go
+++ b/pkg/zstore/zstore_test.go
@@ -1,0 +1,423 @@
+package zstore_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/zarlcorp/core/pkg/zfilesystem"
+	"github.com/zarlcorp/core/pkg/zstore"
+)
+
+func TestOpenFirstRun(t *testing.T) {
+	fs := zfilesystem.NewMemFS()
+	s, err := zstore.Open(fs, []byte("password"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	// salt and verify files should exist
+	if _, err := fs.ReadFile("salt"); err != nil {
+		t.Fatal("salt file not created")
+	}
+	if _, err := fs.ReadFile("verify"); err != nil {
+		t.Fatal("verify file not created")
+	}
+}
+
+func TestOpenSubsequentRun(t *testing.T) {
+	fs := zfilesystem.NewMemFS()
+
+	s1, err := zstore.Open(fs, []byte("password"))
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	s1.Close()
+
+	s2, err := zstore.Open(fs, []byte("password"))
+	if err != nil {
+		t.Fatalf("second open: %v", err)
+	}
+	s2.Close()
+}
+
+func TestOpenWrongPassword(t *testing.T) {
+	fs := zfilesystem.NewMemFS()
+
+	s, err := zstore.Open(fs, []byte("correct"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	s.Close()
+
+	_, err = zstore.Open(fs, []byte("wrong"))
+	if !errors.Is(err, zstore.ErrWrongPassword) {
+		t.Fatalf("expected ErrWrongPassword, got %v", err)
+	}
+}
+
+func TestCollectionPutGet(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+
+	type item struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+
+	col, err := zstore.NewCollection[item](s, "items")
+	if err != nil {
+		t.Fatalf("new collection: %v", err)
+	}
+
+	want := item{Name: "widget", Count: 42}
+	if err := col.Put("w1", want); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	got, err := col.Get("w1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestCollectionGetNotFound(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+
+	col, err := zstore.NewCollection[string](s, "things")
+	if err != nil {
+		t.Fatalf("new collection: %v", err)
+	}
+
+	_, err = col.Get("nonexistent")
+	if !errors.Is(err, zstore.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestCollectionDelete(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+
+	col, err := zstore.NewCollection[string](s, "things")
+	if err != nil {
+		t.Fatalf("new collection: %v", err)
+	}
+
+	if err := col.Put("k1", "value1"); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	if err := col.Delete("k1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	_, err = col.Get("k1")
+	if !errors.Is(err, zstore.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestCollectionDeleteNotFound(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+
+	col, err := zstore.NewCollection[string](s, "things")
+	if err != nil {
+		t.Fatalf("new collection: %v", err)
+	}
+
+	err = col.Delete("nonexistent")
+	if !errors.Is(err, zstore.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestCollectionList(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+
+	col, err := zstore.NewCollection[string](s, "names")
+	if err != nil {
+		t.Fatalf("new collection: %v", err)
+	}
+
+	inputs := map[string]string{
+		"a": "alice",
+		"b": "bob",
+		"c": "charlie",
+	}
+	for id, v := range inputs {
+		if err := col.Put(id, v); err != nil {
+			t.Fatalf("put %s: %v", id, err)
+		}
+	}
+
+	got, err := col.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(got) != len(inputs) {
+		t.Fatalf("list returned %d items, want %d", len(got), len(inputs))
+	}
+
+	// verify all values present (order not guaranteed)
+	found := make(map[string]bool)
+	for _, v := range got {
+		found[v] = true
+	}
+	for _, v := range inputs {
+		if !found[v] {
+			t.Fatalf("list missing value %q", v)
+		}
+	}
+}
+
+func TestCollectionListEmpty(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+
+	col, err := zstore.NewCollection[string](s, "empty")
+	if err != nil {
+		t.Fatalf("new collection: %v", err)
+	}
+
+	got, err := col.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Fatalf("expected empty list, got %d items", len(got))
+	}
+}
+
+func TestCollectionLen(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+
+	col, err := zstore.NewCollection[int](s, "numbers")
+	if err != nil {
+		t.Fatalf("new collection: %v", err)
+	}
+
+	assertLen := func(want int) {
+		t.Helper()
+		n, err := col.Len()
+		if err != nil {
+			t.Fatalf("len: %v", err)
+		}
+		if n != want {
+			t.Fatalf("len = %d, want %d", n, want)
+		}
+	}
+
+	assertLen(0)
+
+	for i := range 5 {
+		if err := col.Put(string(rune('a'+i)), i); err != nil {
+			t.Fatalf("put: %v", err)
+		}
+	}
+	assertLen(5)
+
+	if err := col.Delete(string(rune('a'))); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	assertLen(4)
+}
+
+func TestMultipleCollectionsIsolated(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+
+	type user struct {
+		Name string `json:"name"`
+	}
+
+	type secret struct {
+		Value string `json:"value"`
+	}
+
+	users, err := zstore.NewCollection[user](s, "users")
+	if err != nil {
+		t.Fatalf("new users collection: %v", err)
+	}
+
+	secrets, err := zstore.NewCollection[secret](s, "secrets")
+	if err != nil {
+		t.Fatalf("new secrets collection: %v", err)
+	}
+
+	if err := users.Put("u1", user{Name: "alice"}); err != nil {
+		t.Fatalf("put user: %v", err)
+	}
+
+	if err := secrets.Put("s1", secret{Value: "hunter2"}); err != nil {
+		t.Fatalf("put secret: %v", err)
+	}
+
+	// each collection only sees its own data
+	uLen, err := users.Len()
+	if err != nil {
+		t.Fatalf("users len: %v", err)
+	}
+	if uLen != 1 {
+		t.Fatalf("users len = %d, want 1", uLen)
+	}
+
+	sLen, err := secrets.Len()
+	if err != nil {
+		t.Fatalf("secrets len: %v", err)
+	}
+	if sLen != 1 {
+		t.Fatalf("secrets len = %d, want 1", sLen)
+	}
+
+	// verify the data is correct
+	u, err := users.Get("u1")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if u.Name != "alice" {
+		t.Fatalf("user name = %q, want %q", u.Name, "alice")
+	}
+
+	sv, err := secrets.Get("s1")
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if sv.Value != "hunter2" {
+		t.Fatalf("secret value = %q, want %q", sv.Value, "hunter2")
+	}
+}
+
+func TestPutOverwrite(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+
+	col, err := zstore.NewCollection[string](s, "things")
+	if err != nil {
+		t.Fatalf("new collection: %v", err)
+	}
+
+	if err := col.Put("k1", "first"); err != nil {
+		t.Fatalf("put first: %v", err)
+	}
+
+	if err := col.Put("k1", "second"); err != nil {
+		t.Fatalf("put second: %v", err)
+	}
+
+	got, err := col.Get("k1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got != "second" {
+		t.Fatalf("got %q, want %q", got, "second")
+	}
+
+	n, err := col.Len()
+	if err != nil {
+		t.Fatalf("len: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("len = %d, want 1 after overwrite", n)
+	}
+}
+
+func TestCloseErasesKeys(t *testing.T) {
+	fs := zfilesystem.NewMemFS()
+	s, err := zstore.Open(fs, []byte("password"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	// create a collection to generate a sub-key
+	_, err = zstore.NewCollection[string](s, "test")
+	if err != nil {
+		t.Fatalf("new collection: %v", err)
+	}
+
+	// grab references to the key slices before closing
+	masterKey := s.MasterKeyForTest()
+	subKeys := s.SubKeysForTest()
+
+	s.Close()
+
+	// master key should be zeroed
+	for i, b := range masterKey {
+		if b != 0 {
+			t.Fatalf("master key byte %d = %d, want 0", i, b)
+		}
+	}
+
+	// sub-keys should be zeroed
+	for j, sk := range subKeys {
+		for i, b := range sk {
+			if b != 0 {
+				t.Fatalf("sub-key %d byte %d = %d, want 0", j, i, b)
+			}
+		}
+	}
+}
+
+func TestDataPersistsAcrossOpens(t *testing.T) {
+	fs := zfilesystem.NewMemFS()
+	password := []byte("password")
+
+	// first session: write data
+	s1, err := zstore.Open(fs, password)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+
+	col1, err := zstore.NewCollection[string](s1, "notes")
+	if err != nil {
+		t.Fatalf("new collection: %v", err)
+	}
+
+	if err := col1.Put("n1", "hello"); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	s1.Close()
+
+	// second session: read data
+	s2, err := zstore.Open(fs, password)
+	if err != nil {
+		t.Fatalf("second open: %v", err)
+	}
+	defer s2.Close()
+
+	col2, err := zstore.NewCollection[string](s2, "notes")
+	if err != nil {
+		t.Fatalf("new collection: %v", err)
+	}
+
+	got, err := col2.Get("n1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got != "hello" {
+		t.Fatalf("got %q, want %q", got, "hello")
+	}
+}
+
+// openTestStore creates a store with an in-memory filesystem for testing.
+func openTestStore(t *testing.T) *zstore.Store {
+	t.Helper()
+	fs := zfilesystem.NewMemFS()
+	s, err := zstore.Open(fs, []byte("test-password"))
+	if err != nil {
+		t.Fatalf("open test store: %v", err)
+	}
+	return s
+}


### PR DESCRIPTION
Closes #67

Spec: zarlcorp/core/.manager/specs/095-zstore-encrypted-collections.md

New shared package providing generic encrypted key-value storage built on zfilesystem and zcrypto. Features:
- Master password with Argon2id key derivation
- Per-collection HKDF sub-keys for domain separation
- Typed generic collections with JSON serialization
- Full CRUD: Put, Get, Delete, List, Len
- All tests use MemFS — no disk, no cleanup