### PR TITLE
115: compact ASCII logo

### DIFF
--- a/pkg/zstyle/logo.go
+++ b/pkg/zstyle/logo.go
@@ -3,13 +3,10 @@ package zstyle
 import "github.com/charmbracelet/lipgloss"
 
 // Logo is the zarlcorp ASCII art wordmark for TUI splash screens.
-// ribbon/origami letterforms with diagonal box-drawing characters.
 const Logo = "" +
-	"   ________  ________  ________  ______    ________  ________  ________  ________ \n" +
-	"  ╱        ╲╱        ╲╱        ╲╱      ╲  ╱        ╲╱        ╲╱        ╲╱        ╲\n" +
-	" ╱-        ╱    /    ╱     /   ╱       ╱ ╱         ╱    /    ╱    /    ╱    /    ╱\n" +
-	"╱        _╱         ╱        _╱       ╱_╱       --╱         ╱        _╱       __╱ \n" +
-	"╲________╱╲___╱____╱╲____╱___╱╲________╱╲________╱╲________╱╲____╱___╱╲______╱    "
+	" _  _  _| _ _  _ _ \n" +
+	"/_(_|| |(_(_)| |_)\n" +
+	"               |   "
 
 // StyledLogo returns the logo rendered with the given lipgloss style.
 func StyledLogo(s lipgloss.Style) string {

--- a/pkg/zstyle/logo_test.go
+++ b/pkg/zstyle/logo_test.go
@@ -14,10 +14,10 @@ func TestLogo(t *testing.T) {
 		}
 	})
 
-	t.Run("five lines", func(t *testing.T) {
+	t.Run("three lines", func(t *testing.T) {
 		lines := strings.Split(zstyle.Logo, "\n")
-		if len(lines) != 5 {
-			t.Errorf("Logo has %d lines, want 5", len(lines))
+		if len(lines) != 3 {
+			t.Errorf("Logo has %d lines, want 3", len(lines))
 		}
 	})
 
@@ -43,7 +43,7 @@ func TestStyledLogo(t *testing.T) {
 	}
 	// lipgloss may or may not emit ANSI in test environments,
 	// so we just verify the logo text survives styling
-	if !strings.Contains(got, "╱") {
+	if !strings.Contains(got, "|") {
 		t.Error("StyledLogo output missing logo content")
 	}
 }


### PR DESCRIPTION
Replace the large 5-line ribbon logo with a minimal 3-line zarlcorp wordmark.